### PR TITLE
Fix device log bug

### DIFF
--- a/IOSDeviceLib/Printing.cpp
+++ b/IOSDeviceLib/Printing.cpp
@@ -1,16 +1,24 @@
+#include <mutex>
+
 #include "SocketHelper.h"
 #include "Printing.h"
 #include "Constants.h"
 #include "json.hpp"
 
+std::mutex print_mutex;
+
 void print(const char* str)
 {
+	// We need to lock the print method because in some cases we print different parts of messages
+	// from different threads.
+	print_mutex.lock();
 	LengthEncodedMessage length_encoded_message = get_message_with_encoded_length(str);
 	char* buff = new char[length_encoded_message.length];
 	std::setvbuf(stdout, buff, _IOFBF, length_encoded_message.length);
 	fwrite(length_encoded_message.message, length_encoded_message.length, 1, stdout);
 	fflush(stdout);
 	delete[] buff;
+	print_mutex.unlock();
 }
 
 void print(const nlohmann::json& message)

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,12 @@
+"use strict";
+
+exports.DataEventName = "data";
+exports.DeviceFoundEventName = "deviceFound";
+exports.DeviceLostEventName = "deviceLost";
+
+exports.DeviceEventEnum = {
+	kDeviceFound: "deviceFound",
+	kDeviceLost: "deviceLost",
+	kDeviceTrusted: "deviceTrusted",
+	kDeviceUnknown: "deviceUnknown"
+};

--- a/ios-device-lib-stdio-handler.js
+++ b/ios-device-lib-stdio-handler.js
@@ -13,7 +13,7 @@ const HeaderSize = 4;
 class IOSDeviceLibStdioHandler extends EventEmitter {
 	constructor() {
 		super();
-		this._unfinishedMessage = new Buffer(0);
+		this._unfinishedMessage = Buffer.alloc(0);
 	}
 
 	startReadingData() {
@@ -57,12 +57,13 @@ class IOSDeviceLibStdioHandler extends EventEmitter {
 			// Get the message length header.
 			const messageSizeBuffer = data.slice(0, HeaderSize);
 			const messageLength = bufferpack.unpack(">i", messageSizeBuffer)[0];
+			const dataLengthWithoutHeader = data.length - HeaderSize;
 
-			if (messageLength > data.length - HeaderSize) {
+			if (messageLength > dataLengthWithoutHeader) {
 				// Less than one message in the buffer.
 				// Store the unfinished message untill the next call of the function.
 				this._unfinishedMessage = data;
-			} else if (data.length - 4 > messageLength) {
+			} else if (dataLengthWithoutHeader > messageLength) {
 				// More than one message in the buffer.
 				const messageBuffer = this._getMessageFromBuffer(data, messageLength);
 
@@ -82,7 +83,7 @@ class IOSDeviceLibStdioHandler extends EventEmitter {
 			const concatenatedMessage = Buffer.concat([this._unfinishedMessage, data]);
 
 			// Clear the unfinished message buffer.
-			this._unfinishedMessage = new Buffer(0);
+			this._unfinishedMessage = Buffer.alloc(0);
 			this._unpackMessages(concatenatedMessage);
 		} else {
 			// While debugging the data here contains one character - \0, null or 0.

--- a/ios-device-lib-stdio-handler.js
+++ b/ios-device-lib-stdio-handler.js
@@ -1,0 +1,106 @@
+"use strict";
+
+const EventEmitter = require("events");
+const path = require("path");
+const os = require("os");
+const spawn = require("child_process").spawn;
+
+const bufferpack = require("bufferpack");
+const Constants = require("./constants");
+
+const HeaderSize = 4;
+
+class IOSDeviceLibStdioHandler extends EventEmitter {
+	constructor() {
+		super();
+		this._unfinishedMessage = new Buffer(0);
+	}
+
+	startReadingData() {
+		this._chProc = spawn(path.join(__dirname, "bin", os.platform(), os.arch(), "ios-device-lib"));
+		this._chProc.stdout.on("data", (data) => {
+			this._unpackMessages(data);
+		});
+	}
+
+	writeData(data) {
+		this._chProc.stdin.write(data);
+	}
+
+	dispose(signal) {
+		this.removeAllListeners();
+		this._chProc.removeAllListeners();
+		this._chProc.kill(signal);
+	}
+
+	_distributeMessage(message) {
+		if (message.event) {
+			switch (message.event) {
+				case Constants.DeviceEventEnum.kDeviceFound:
+					this.emit(Constants.DeviceFoundEventName, message);
+					break;
+				case DeviceEventEnum.kDeviceLost:
+					this.emit(Constants.DeviceLostEventName, message);
+					break;
+				case DeviceEventEnum.kDeviceTrusted:
+					this.emit(Constants.DeviceLostEventName, message);
+					this.emit(Constants.DeviceFoundEventName, message);
+					break;
+			}
+		} else {
+			this.emit(Constants.DataEventName, message);
+		}
+	}
+
+	_unpackMessages(data) {
+		if (!this._unfinishedMessage.length && data.length >= HeaderSize) {
+			// Get the message length header.
+			const messageSizeBuffer = data.slice(0, HeaderSize);
+			const messageLength = bufferpack.unpack(">i", messageSizeBuffer)[0];
+
+			if (messageLength > data.length - HeaderSize) {
+				// Less than one message in the buffer.
+				// Store the unfinished message untill the next call of the function.
+				this._unfinishedMessage = data;
+			} else if (data.length - 4 > messageLength) {
+				// More than one message in the buffer.
+				const messageBuffer = this._getMessageFromBuffer(data, messageLength);
+
+				// Get the rest of the message here.
+				// Since our messages are not separated by whitespace or newlie
+				// we do not need to add somethig when we slice the original buffer.
+				const slicedBuffer = data.slice(messageBuffer.length + HeaderSize);
+				this._distributeMessage(this._parseMessageFromBuffer(messageBuffer));
+				this._unpackMessages(slicedBuffer);
+			} else {
+				// One message in the buffer.
+				const messageBuffer = this._getMessageFromBuffer(data, messageLength);
+				this._distributeMessage(this._parseMessageFromBuffer(messageBuffer));
+			}
+		} else if (this._unfinishedMessage.length && data.length >= HeaderSize) {
+			// Append the new data to the unfinished message and try to unpack again.
+			const concatenatedMessage = Buffer.concat([this._unfinishedMessage, data]);
+
+			// Clear the unfinished message buffer.
+			this._unfinishedMessage = new Buffer(0);
+			this._unpackMessages(concatenatedMessage);
+		} else {
+			// While debugging the data here contains one character - \0, null or 0.
+			// I think we get here when the Node inner buffer for the data of the data event
+			// is filled with data and the last symbol is a part of the length header of the next message.
+			// That's why we need this concat.
+			// This code is tested with 10 000 000 messages in while loop.
+			this._unfinishedMessage = Buffer.concat([this._unfinishedMessage, data]);
+		}
+	}
+
+	_getMessageFromBuffer(buffer, messageLength) {
+		return buffer.slice(HeaderSize, messageLength + HeaderSize);
+	}
+
+	_parseMessageFromBuffer(buffer) {
+		return JSON.parse(buffer.toString().trim());
+	}
+}
+
+exports.IOSDeviceLibStdioHandler = IOSDeviceLibStdioHandler;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
When we get the device log the C++ code starts to print on the stdout and in the JavaScript code we listen for the data event. If there is enough time between each message which is printed on the stdout the data event is raised with only one message. If the C++ code starts to print on the stdout too fast (which is the case with the device log) NodeJS buffers all the data and emits data event with all the buffered data. This breaks out code because we expect only one message. The solution for this problem is to write method which will "parse" the buffered data. This method should check the header of the received buffered data and read message from the buffered data. If there is full message in the buffered data we will read it. If there is no full message we should store the unfinished message and on the next received buffered data we should concat the unfinished message and the new data and try to parse the concatenated message. We rely on that the first message should have header with length. After that the method will make sure that the unfinished message will always begin with header with length and that each recursive call will receive data which begins with header with length.

While testing the new method with 7 threads which print on the stdout we noticed that at some point the data which is printed on the stdout gets malformed. For example with this message:
```JSON
{"message1":"Feb 10 13:59: 28 dragon - iPhone6 timed[65] <Notice> : (Error)TimeLink : B76E090A - 9807 - 4AA3 - BB01 - 3CDE3DD48D55(4 \n- TMLSSourceDevice) send failure(Error Domain = com.apple.identityservices.error Code = 23 UserInfo=0x12fe326f0 {NSLocalizedDescription=Timed out, NSUnderlyingError=0x12fe34190 The operation couldnt be completed. (com.apple.ids.idssenderrordomain error 12.)}), will retry"}
```
we receive random number of messages before we receive one message with additional `}`. With one thread we do not receive malformed output. To solve this problem we need to add mutex in the print method and make it thread safe.