### PR TITLE
Fix tns debug issues

### DIFF
--- a/IOSDeviceLib.xcodeproj/project.pbxproj
+++ b/IOSDeviceLib.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		709A6CD11E435D11006F76C7 /* mac_impl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 709A6CCD1E435D11006F76C7 /* mac_impl.cpp */; };
 		709A6CD21E435D11006F76C7 /* Printing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 709A6CCE1E435D11006F76C7 /* Printing.cpp */; };
 		709A6CD31E435D11006F76C7 /* windows_impl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 709A6CD01E435D11006F76C7 /* windows_impl.cpp */; };
+		70DFE7601E72ACCC000317B3 /* ServerHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70DFE75E1E72ACCC000317B3 /* ServerHelper.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -330,6 +331,8 @@
 		709A6CCE1E435D11006F76C7 /* Printing.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Printing.cpp; sourceTree = "<group>"; };
 		709A6CCF1E435D11006F76C7 /* Printing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Printing.h; sourceTree = "<group>"; };
 		709A6CD01E435D11006F76C7 /* windows_impl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = windows_impl.cpp; sourceTree = "<group>"; };
+		70DFE75E1E72ACCC000317B3 /* ServerHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ServerHelper.cpp; sourceTree = "<group>"; };
+		70DFE75F1E72ACCC000317B3 /* ServerHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServerHelper.h; sourceTree = "<group>"; };
 		70F5F4281E13EE02005196BF /* configuration.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = configuration.xcconfig; path = IOSDeviceLib/configuration.xcconfig; sourceTree = "<group>"; };
 		70F6ADAB1DEEB71300DD4722 /* ios-device-lib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "ios-device-lib"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -350,6 +353,8 @@
 		7038C9EF1DEEDB4C00A3D335 /* IOSDeviceLib */ = {
 			isa = PBXGroup;
 			children = (
+				70DFE75E1E72ACCC000317B3 /* ServerHelper.cpp */,
+				70DFE75F1E72ACCC000317B3 /* ServerHelper.h */,
 				709A6CCB1E435D11006F76C7 /* CommonFunctions.h */,
 				709A6CCC1E435D11006F76C7 /* Constants.h */,
 				709A6CCD1E435D11006F76C7 /* mac_impl.cpp */,
@@ -1158,6 +1163,7 @@
 				7024956E1E4080B8009A6EBF /* FileHelper.cpp in Sources */,
 				7038CB3E1DEEDB4C00A3D335 /* PlistDate.cpp in Sources */,
 				709A6CD31E435D11006F76C7 /* windows_impl.cpp in Sources */,
+				70DFE7601E72ACCC000317B3 /* ServerHelper.cpp in Sources */,
 				7038CB3D1DEEDB4C00A3D335 /* Plist.cpp in Sources */,
 				709A6CD21E435D11006F76C7 /* Printing.cpp in Sources */,
 				7024956F1E4080B8009A6EBF /* GDBHelper.cpp in Sources */,

--- a/IOSDeviceLib/Constants.h
+++ b/IOSDeviceLib/Constants.h
@@ -65,6 +65,7 @@ static const char *kShouldWaitForResponse = "shouldWaitForResponse";
 static const char *kCommandType = "commandType";
 static const char *kTimeout = "timeout";
 static const char *kPort = "port";
+static const char *kHost = "host";
 static const char *kComplete = "Complete";
 static const char *kCode = "code";
 static const char *kProductVersion = "ProductVersion";
@@ -79,3 +80,5 @@ static const std::string kFilePrefix("file:///");
 static const std::string kDocumentsFolder("/Documents/");
 static const std::string kVendDocumentsCommandName("VendDocuments");
 static const std::string kVendContainerCommandName("VendContainer");
+
+static const char *kLocalhostAddress = "127.0.0.1";

--- a/IOSDeviceLib/Constants.h
+++ b/IOSDeviceLib/Constants.h
@@ -38,6 +38,7 @@ static const char *kDeviceFound = "deviceFound";
 static const char *kDeviceLost = "deviceLost";
 static const char *kDeviceTrusted = "deviceTrusted";
 static const char *kDeviceUnknown = "deviceUnknown";
+static const char *kSocketMessageReceived = "socketMessageReceived";
 
 static const char *kId = "id";
 static const char *kNullMessageId = "null";

--- a/IOSDeviceLib/Constants.h
+++ b/IOSDeviceLib/Constants.h
@@ -56,6 +56,7 @@ static const char *kErrorKey = "Error";
 static const char *kCommandKey = "Command";
 static const char *kStatusKey = "Status";
 static const char *kResponse = "response";
+static const char *kSocket = "socket";
 static const char *kMessage = "message";
 static const char *kResponseCommandType = "responseCommandType";
 static const char *kResponsePropertyName = "responsePropertyName";

--- a/IOSDeviceLib/Declarations.h
+++ b/IOSDeviceLib/Declarations.h
@@ -104,10 +104,20 @@ struct DeviceData {
 	std::map<const char*, HANDLE> services;
 	int sessions;
 	std::map<std::string, ApplicationCache> apps_cache;
+	struct DeviceServerData* device_server_data;
 
-	//~DeviceData() {
-	//	//device_info
-	//}
+	void kill_device_server()
+	{
+		if (device_server_data != nullptr)
+		{
+			delete device_server_data;
+			device_server_data = nullptr;
+		}
+	}
+
+	~DeviceData() {
+		kill_device_server();
+	}
 };
 
 struct FileUploadData {

--- a/IOSDeviceLib/Declarations.h
+++ b/IOSDeviceLib/Declarations.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #pragma region Macros
-#define RETURN_IF_FAILED_RESULT(expr) ; if((__result = (expr))) { return __result; }
+#define UNLOCK_MUTEX_AND_RETURN_IF_FAILED_RESULT(expr, mutex) ; if((__result = (expr))) { mutex.unlock(); return __result; }
 #define PRINT_ERROR_AND_RETURN_VALUE_IF_FAILED_RESULT(expr, error_msg, device_identifier, method_id, value) ; if((__result = (expr))) { print_error(error_msg, device_identifier, method_id, __result); return value; }
 #define PRINT_ERROR_AND_RETURN_IF_FAILED_RESULT(expr, error_msg, device_identifier, method_id) ; if((__result = (expr))) { print_error(error_msg, device_identifier, method_id, __result); return; }
 #pragma endregion Macros

--- a/IOSDeviceLib/Declarations.h
+++ b/IOSDeviceLib/Declarations.h
@@ -101,10 +101,10 @@ struct ApplicationCache {
 
 struct DeviceData {
 	DeviceInfo* device_info;
+	struct DeviceServerData* device_server_data;
 	std::map<const char*, HANDLE> services;
 	int sessions;
 	std::map<std::string, ApplicationCache> apps_cache;
-	struct DeviceServerData* device_server_data;
 
 	void kill_device_server()
 	{
@@ -113,10 +113,6 @@ struct DeviceData {
 			delete device_server_data;
 			device_server_data = nullptr;
 		}
-	}
-
-	~DeviceData() {
-		kill_device_server();
 	}
 };
 

--- a/IOSDeviceLib/Declarations.h
+++ b/IOSDeviceLib/Declarations.h
@@ -27,9 +27,13 @@ struct PostNotificationInfo
 {
 	std::string command_type;
 	std::string notification_name;
+};
+
+struct AwaitNotificationResponseInfo
+{
 	std::string response_command_type;
 	std::string response_property_name;
-	bool should_wait_for_response;
+	SOCKET socket;
 	int timeout;
 };
 

--- a/IOSDeviceLib/Declarations.h
+++ b/IOSDeviceLib/Declarations.h
@@ -9,17 +9,14 @@
 #ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>
-#include <winsock2.h>
-#include <ws2tcpip.h>
 
 #pragma comment(lib, "Ws2_32.lib")
-#else
-typedef void* HANDLE;
-typedef unsigned long long SOCKET;
 #endif // _WIN32
 
 #include <string>
 #include <map>
+
+#include "ServerHelper.h"
 
 #pragma region Data_Structures_Definition
 

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -1405,7 +1405,7 @@ int main()
 					stop_app(device_identifier, application_identifier, ddi, method_id);
 				}
 			}
-			else if (method_name == "connect")
+			else if (method_name == "connectToPort")
 			{
 				for (json &arg : method_args)
 				{

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -1253,7 +1253,7 @@ int main()
 #ifdef _WIN32
 	_setmode(_fileno(stdout), _O_BINARY);
 
-	if (!load_dlls())
+	if (load_dlls())
 	{
 		return -1;
 	}

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -1044,8 +1044,8 @@ void device_log(std::string device_identifier, std::string method_id)
 
 void post_notification(std::string device_identifier, PostNotificationInfo post_notification_info, std::string method_id)
 {
-	HANDLE socket = start_service(device_identifier, kNotificationProxy, method_id);
-	if (!socket)
+	HANDLE handle = start_service(device_identifier, kNotificationProxy, method_id);
+	if (!handle)
 	{
 		return;
 	}
@@ -1069,8 +1069,9 @@ void post_notification(std::string device_identifier, PostNotificationInfo post_
 							"<string></string>"
 						"</dict>"
 						"</plist>";
-
-	send_message(xml_command.str().c_str(), (SOCKET)socket);
+	
+	SOCKET socket = (SOCKET)handle;
+	send_message(xml_command.str().c_str(), socket);
 	print(json({ { kResponse, socket }, { kId, method_id }, { kDeviceId, device_identifier } }));
 }
 
@@ -1380,11 +1381,11 @@ int main()
 					std::thread([=]() { post_notification(device_identifier, post_notification_info, method_id); }).detach();
 				}
 			}
-			else if (method_name == "awaitNotificatioNResponse")
+			else if (method_name == "awaitNotificationResponse")
 			{
 				for (json &arg : method_args)
 				{
-					if (!validate_device_id_and_attrs(arg, method_id, { kResponseCommandType, kSocket, kResponsePropertyName }))
+					if (!validate_device_id_and_attrs(arg, method_id, { kResponseCommandType, kResponsePropertyName }))
 						continue;
 
 					std::string device_identifier = arg.value(kDeviceId, "");

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -1244,13 +1244,13 @@ void connect_to_port(std::string device_identifier, int port, std::string method
 	else
 	{
 		DeviceServerData server_socket_data = create_server(device_socket, kLocalhostAddress);
-		device.device_server_data = &server_socket_data;
 		if (server_socket_data.server_socket <= 0)
 		{
 			print_error("Failed to start the proxy server between the Chrome Dev Tools and the iOS device.", device_identifier, method_id);
 			return;
 		}
 
+		device.device_server_data = &server_socket_data;
 		// We can use the device socket which is returned from USBMuxConnectByPort only in the C++ code.
 		// That's why we need to create a server which will serve to expose the socket.
 		// When we receive a client connection we will create a client socket.
@@ -1453,7 +1453,7 @@ int main()
 					stop_app(device_identifier, application_identifier, ddi, method_id);
 				}
 			}
-			else if (method_name == "connectToDeviceSocket")
+			else if (method_name == "connectToPort")
 			{
 				for (json &arg : method_args)
 				{

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -1243,9 +1243,23 @@ void connect_to_port(std::string device_identifier, int port, std::string method
 
 void send_message_to_socket(std::string device_identifier, SOCKET socket, std::string message, std::string method_id)
 {
-	int bytes_sent = send_message(message, socket);
+	int bytes_sent = send_utf16_message(message, socket, message.size());
 
 	print(json({ { kResponse, bytes_sent }, { kId, method_id }, { kDeviceId, device_identifier } }));
+}
+
+void read_messages_from_socket(std::string device_identifier, SOCKET socket, std::string method_id)
+{
+	// TODO: check if we need to pass different message length
+	// because we will receive utf16 messages.
+	std::string message;
+	
+	while ((message = receive_message_raw(socket)).size() > 0)
+	{
+		print(json({ { kMessage, message }, { kDeviceId, device_identifier}, { kId, method_id }, { kSocket, socket }, { kEventString, kSocketMessageReceived } }));
+		// TODO: discuss the sleep duration.
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	}
 }
 
 int main()
@@ -1444,6 +1458,15 @@ int main()
 					std::string device_identifier = arg.value(kDeviceId, "");
 					std::string message = arg.value(kMessage, "");
 					std::thread([=]() { send_message_to_socket(device_identifier, socket, message, method_id); }).detach();
+				}
+			}
+			else if (method_name == "readMessagesFromSocket")
+			{
+				for (json &arg : method_args)
+				{
+					SOCKET socket = arg.value(kSocket, -1);
+					std::string device_identifier = arg.value(kDeviceId, "");
+					std::thread([=]() { read_messages_from_socket(device_identifier, socket, method_id); }).detach();
 				}
 			}
 			else if (method_name == "exit")

--- a/IOSDeviceLib/IOSDeviceLib.vcxproj
+++ b/IOSDeviceLib/IOSDeviceLib.vcxproj
@@ -100,6 +100,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <ShowIncludes>false</ShowIncludes>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,6 +116,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <ShowIncludes>false</ShowIncludes>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/IOSDeviceLib/IOSDeviceLib.vcxproj
+++ b/IOSDeviceLib/IOSDeviceLib.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="PlistCpp\PlistDate.cpp" />
     <ClCompile Include="PlistCpp\pugixml.cpp" />
     <ClCompile Include="Printing.cpp" />
+    <ClCompile Include="ServerHelper.cpp" />
     <ClCompile Include="SocketHelper.cpp" />
     <ClCompile Include="StringHelper.cpp" />
     <ClCompile Include="windows_impl.cpp" />
@@ -450,6 +451,7 @@
     <ClInclude Include="PlistCpp\pugiconfig.hpp" />
     <ClInclude Include="PlistCpp\pugixml.hpp" />
     <ClInclude Include="Printing.h" />
+    <ClInclude Include="ServerHelper.h" />
     <ClInclude Include="SocketHelper.h" />
     <ClInclude Include="StringHelper.h" />
   </ItemGroup>

--- a/IOSDeviceLib/IOSDeviceLib.vcxproj.filters
+++ b/IOSDeviceLib/IOSDeviceLib.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClCompile Include="Printing.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ServerHelper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="IOSDeviceLib.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -882,6 +885,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="CommonFunctions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ServerHelper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/IOSDeviceLib/Printing.cpp
+++ b/IOSDeviceLib/Printing.cpp
@@ -1,5 +1,3 @@
-#include <mutex>
-
 #include "SocketHelper.h"
 #include "Printing.h"
 #include "Constants.h"

--- a/IOSDeviceLib/Printing.cpp
+++ b/IOSDeviceLib/Printing.cpp
@@ -6,19 +6,35 @@
 #include "json.hpp"
 
 std::mutex print_mutex;
-
-void print(const char* str)
+void print_core(const char* str, FILE *destinaton)
 {
 	// We need to lock the print method because in some cases we print different parts of messages
 	// from different threads.
 	print_mutex.lock();
 	LengthEncodedMessage length_encoded_message = get_message_with_encoded_length(str);
 	char* buff = new char[length_encoded_message.length];
-	std::setvbuf(stdout, buff, _IOFBF, length_encoded_message.length);
-	fwrite(length_encoded_message.message, length_encoded_message.length, 1, stdout);
-	fflush(stdout);
+	std::setvbuf(destinaton, buff, _IOFBF, length_encoded_message.length);
+	fwrite(length_encoded_message.message, length_encoded_message.length, 1, destinaton);
+	fflush(destinaton);
 	delete[] buff;
 	print_mutex.unlock();
+}
+
+void print(const char* str)
+{
+	print_core(str, stdout);
+}
+
+void trace(const char* str)
+{
+	print_core(str, stderr);
+}
+
+void trace(int num)
+{
+	std::stringstream str;
+	str << num;
+	trace(str.str().c_str());
 }
 
 void print(const nlohmann::json& message)

--- a/IOSDeviceLib/Printing.cpp
+++ b/IOSDeviceLib/Printing.cpp
@@ -1,3 +1,5 @@
+#include <mutex>
+
 #include "SocketHelper.h"
 #include "Printing.h"
 #include "Constants.h"

--- a/IOSDeviceLib/Printing.h
+++ b/IOSDeviceLib/Printing.h
@@ -7,6 +7,8 @@
 #include <string>
 #include "Constants.h"
 
+void trace(const char* str);
+void trace(int num);
 void print(const char* str);
 void print(const nlohmann::json& message);
 void print_error(const char *message, std::string device_identifier, std::string method_id, int code =

--- a/IOSDeviceLib/ServerHelper.cpp
+++ b/IOSDeviceLib/ServerHelper.cpp
@@ -8,7 +8,7 @@ struct sockaddr_in bind_socket(SOCKET socket, const char* host)
 	server_address.sin_family = AF_INET;
 
 #ifdef _WIN32
-	server_address.sin_addr.s_addr = inet_pton(server_address.sin_family, host, (void*)&server_address.sin_addr);
+	inet_pton(server_address.sin_family, host, (void*)&server_address.sin_addr);
 #else
 	server_address.sin_addr.s_addr = inet_addr(host);
 #endif // _WIN32
@@ -18,7 +18,8 @@ struct sockaddr_in bind_socket(SOCKET socket, const char* host)
 	server_address.sin_port = htons(port);
 
 	// If the port is available the bind() will return 0.
-	while (bind(socket, (sockaddr*)&server_address, address_length) != 0)
+	auto bind_result = bind(socket, (sockaddr*)&server_address, address_length);
+	while (bind_result != 0)
 	{
 		++port;
 		server_address.sin_port = htons(port);

--- a/IOSDeviceLib/ServerHelper.cpp
+++ b/IOSDeviceLib/ServerHelper.cpp
@@ -1,6 +1,4 @@
-#include "ServerHelper.h";
-
-std::vector<DeviceServerData*> servers;
+#include "ServerHelper.h"
 
 struct sockaddr_in bind_socket(SOCKET socket, const char* host)
 {
@@ -47,9 +45,5 @@ DeviceServerData create_server(SOCKET device_socket, const char* host)
 
 	listen(server_socket, SOMAXCONN);
 
-	DeviceServerData result = { server_socket, device_socket, server_address };
-
-	servers.push_back(&result);
-
-	return result;
+	return { server_socket, device_socket, server_address };
 }

--- a/IOSDeviceLib/ServerHelper.cpp
+++ b/IOSDeviceLib/ServerHelper.cpp
@@ -1,0 +1,55 @@
+#include "ServerHelper.h";
+
+std::vector<DeviceServerData*> servers;
+
+struct sockaddr_in bind_socket(SOCKET socket, const char* host)
+{
+	struct sockaddr_in server_address;
+	socklen_t address_length = sizeof(server_address);
+
+	server_address.sin_family = AF_INET;
+
+#ifdef _WIN32
+	server_address.sin_addr.s_addr = inet_pton(server_address.sin_family, host, (void*)&server_address.sin_addr);
+#else
+	server_address.sin_addr.s_addr = inet_addr(host);
+#endif // _WIN32
+
+	// Find available port.
+	int port = 1111;
+	server_address.sin_port = htons(port);
+
+	// If the port is available the bind() will return 0.
+	while (bind(socket, (sockaddr*)&server_address, address_length) != 0)
+	{
+		++port;
+		server_address.sin_port = htons(port);
+	}
+
+	return server_address;
+}
+
+DeviceServerData create_server(SOCKET device_socket, const char* host)
+{
+# ifdef _WIN32
+	// Start WinSock2
+	WSADATA wsa_data;
+	WORD dll_version = MAKEWORD(2, 1);
+	if (WSAStartup(dll_version, &wsa_data) != 0)
+	{
+		return { 0, 0, NULL };
+	}
+#endif // _WIN32
+
+	SOCKET server_socket = socket(AF_INET, SOCK_STREAM, NULL);
+
+	struct sockaddr_in server_address = bind_socket(server_socket, host);
+
+	listen(server_socket, SOMAXCONN);
+
+	DeviceServerData result = { server_socket, device_socket, server_address };
+
+	servers.push_back(&result);
+
+	return result;
+}

--- a/IOSDeviceLib/ServerHelper.cpp
+++ b/IOSDeviceLib/ServerHelper.cpp
@@ -27,7 +27,7 @@ struct sockaddr_in bind_socket(SOCKET socket, const char* host)
 	return server_address;
 }
 
-DeviceServerData create_server(SOCKET device_socket, const char* host)
+DeviceServerData* create_server(SOCKET device_socket, const char* host)
 {
 # ifdef _WIN32
 	// Start WinSock2
@@ -35,7 +35,7 @@ DeviceServerData create_server(SOCKET device_socket, const char* host)
 	WORD dll_version = MAKEWORD(2, 1);
 	if (WSAStartup(dll_version, &wsa_data) != 0)
 	{
-		return { 0, 0, NULL };
+		return nullptr;
 	}
 #endif // _WIN32
 
@@ -45,5 +45,10 @@ DeviceServerData create_server(SOCKET device_socket, const char* host)
 
 	listen(server_socket, SOMAXCONN);
 
-	return { server_socket, device_socket, server_address };
+	DeviceServerData* result = new DeviceServerData();
+	result->server_socket = server_socket;
+	result->device_socket = device_socket;
+	result->server_address = server_address;
+
+	return result;
 }

--- a/IOSDeviceLib/ServerHelper.h
+++ b/IOSDeviceLib/ServerHelper.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#ifdef _WIN32
+#include <winsock2.h>
+#endif // _WIN32
+
+#include <algorithm>
+#include <ws2tcpip.h>
+#include <vector>;
+
+struct DeviceServerData {
+	SOCKET server_socket;
+	SOCKET device_socket;
+	struct sockaddr_in server_address;
+
+	~DeviceServerData()
+	{
+		// We need closesocket for Windows because the socket
+		// is a handle to kernel object instead of *nix file descriptor
+		// http://stackoverflow.com/questions/35441815/are-close-and-closesocket-interchangable
+#ifdef _WIN32
+		closesocket(server_socket);
+		closesocket(device_socket);
+#else
+		close(server_socket);
+		close(device_socket);
+#endif // _WIN32
+	}
+};
+
+struct sockaddr_in bind_socket(SOCKET socket, const char* host);
+DeviceServerData create_server(SOCKET device_socket, const char* host);

--- a/IOSDeviceLib/ServerHelper.h
+++ b/IOSDeviceLib/ServerHelper.h
@@ -2,11 +2,15 @@
 
 #ifdef _WIN32
 #include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "Declarations.h"
 #endif // _WIN32
 
 #include <algorithm>
-#include <ws2tcpip.h>
-#include <vector>;
+#include <vector>
 
 struct DeviceServerData {
 	SOCKET server_socket;

--- a/IOSDeviceLib/ServerHelper.h
+++ b/IOSDeviceLib/ServerHelper.h
@@ -1,16 +1,11 @@
 #pragma once
 
-#ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#else
+#ifndef _WIN32
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include "Declarations.h"
 #endif // _WIN32
 
-#include <algorithm>
-#include <vector>
+#include "SocketHelper.h"
 
 struct DeviceServerData {
 	SOCKET server_socket;
@@ -19,18 +14,11 @@ struct DeviceServerData {
 
 	~DeviceServerData()
 	{
-		// We need closesocket for Windows because the socket
-		// is a handle to kernel object instead of *nix file descriptor
-		// http://stackoverflow.com/questions/35441815/are-close-and-closesocket-interchangable
-#ifdef _WIN32
-		closesocket(server_socket);
-		closesocket(device_socket);
-#else
-		close(server_socket);
-		close(device_socket);
-#endif // _WIN32
+		close_socket(server_socket);
+		close_socket(device_socket);
 	}
 };
 
 struct sockaddr_in bind_socket(SOCKET socket, const char* host);
 DeviceServerData* create_server(SOCKET device_socket, const char* host);
+struct DeviceServerData;

--- a/IOSDeviceLib/ServerHelper.h
+++ b/IOSDeviceLib/ServerHelper.h
@@ -33,4 +33,4 @@ struct DeviceServerData {
 };
 
 struct sockaddr_in bind_socket(SOCKET socket, const char* host);
-DeviceServerData create_server(SOCKET device_socket, const char* host);
+DeviceServerData* create_server(SOCKET device_socket, const char* host);

--- a/IOSDeviceLib/SocketHelper.cpp
+++ b/IOSDeviceLib/SocketHelper.cpp
@@ -10,17 +10,6 @@ int send_message(const char* message, SOCKET socket, long long length)
 	return send(socket, length_encoded_message.message, length_encoded_message.length, 0);
 }
 
-int send_utf16_message(std::string message, SOCKET socket, long long length)
-{
-	Utf16Message utf16_message = get_utf16_message_with_encoded_length(message.c_str(), length);
-#ifdef _WIN32
-	const char *message_buffer = (const char*)utf16_message.message;
-#else
-	const unsigned char *message_buffer = utf16_message.message;
-#endif // _WIN32
-	return send(socket, message_buffer, utf16_message.length, 0);
-}
-
 int send_message(std::string message, SOCKET socket, long long length)
 {
 	return send_message(message.c_str(), socket, length);
@@ -68,6 +57,107 @@ std::map<std::string, boost::any> receive_message(SOCKET socket)
 	return dict;
 }
 
+std::mutex receive_utf16_message_mutex;
+Utf16Message* receive_utf16_message(SOCKET fd, int size = 1000)
+{
+	receive_utf16_message_mutex.lock();
+	// We do not want to stay at recv forever.
+	int should_read_from_socket_result = should_read_from_socket(fd, 1);
+	if (should_read_from_socket_result == 0)
+	{
+		Utf16Message* empty_result = new Utf16Message();
+		empty_result->message = new unsigned char[0];
+		empty_result->length = 0;
+		receive_utf16_message_mutex.unlock();
+		return empty_result;
+	}
+	else if (should_read_from_socket_result == -1)
+	{
+		receive_utf16_message_mutex.unlock();
+		return nullptr;
+	}
+
+	int bytes_read;
+	long long final_length = 0;
+	// We need to create new unsigned char[] here because if we don't
+	// the memcpy will fail with EXC_BAD_ACCESS
+	unsigned char *result = new unsigned char[0];
+
+	do
+	{
+		unsigned char *buffer = new unsigned char[size];
+		bytes_read = recv(fd, (char*)buffer, size, 0);
+
+		if (bytes_read > 0)
+		{
+			size_t temp_size = final_length + bytes_read;
+			unsigned char *temp = new unsigned char[temp_size + 1];
+
+			memcpy(temp, result, final_length);
+			memcpy(temp + final_length, buffer, bytes_read);
+
+			// Delete the result because we change it's address to temp's address.
+			delete[] result;
+			result = temp;
+			final_length += bytes_read;
+		}
+		else if (bytes_read < 0)
+		{
+			receive_utf16_message_mutex.unlock();
+			return nullptr;
+		}
+
+		delete[] buffer;
+	} while (bytes_read == size);
+
+	Utf16Message* utf16_message = new Utf16Message();
+	utf16_message->message = result;
+	utf16_message->length = final_length;
+
+	receive_utf16_message_mutex.unlock();
+
+	return utf16_message;
+}
+
+void proxy_socket_messages(SOCKET first, SOCKET second)
+{
+	Utf16Message* message;
+
+	while ((message = receive_utf16_message(first)) != nullptr)
+	{
+		if (message->length)
+		{
+#ifdef _WIN32
+			char* message_buffer = (char*)message->message;
+#else
+			unsigned char* message_buffer = message->message;
+#endif // _WIN32
+
+			send(second, message_buffer, message->length, NULL);
+		}
+
+		// Delete the message to free the message->message memory.
+		delete message;
+	}
+}
+
+void proxy_socket_io(SOCKET first, SOCKET second, std::function<void(SOCKET, SOCKET)> socket_closed_callback)
+{
+	std::thread([=]()
+	{
+		// Send the messages received on the first socket to the second socket.
+		proxy_socket_messages(first, second);
+		socket_closed_callback(first, second);
+	});
+
+	std::thread([=]()
+	{
+		// Send the messages received on the second socket to the first socket.
+		proxy_socket_messages(second, first);
+		socket_closed_callback(first, second);
+	});
+}
+
 std::string receive_message_raw(SOCKET socket, int size)
 {
 	int bytes_read;
@@ -96,18 +186,4 @@ LengthEncodedMessage get_message_with_encoded_length(const char* message, long l
 	memcpy(length_encoded_message, &packed_length, packed_length_size);
 	memcpy(length_encoded_message + packed_length_size, message, length);
 	return{ length_encoded_message, message_len };
-}
-
-Utf16Message get_utf16_message_with_encoded_length(const char* message, long long length)
-{
-	if (length < 0)
-		length = strlen(message);
-
-	unsigned long message_len = length + 4;
-	unsigned char *utf16_message = new unsigned char[message_len];
-	unsigned long packed_length = htonl(length);
-	size_t packed_length_size = 4;
-	memcpy(utf16_message, &packed_length, packed_length_size);
-	memcpy(utf16_message + packed_length_size, message, length);
-	return{ utf16_message, message_len };
 }

--- a/IOSDeviceLib/SocketHelper.cpp
+++ b/IOSDeviceLib/SocketHelper.cpp
@@ -141,21 +141,19 @@ void proxy_socket_messages(SOCKET first, SOCKET second)
 	}
 }
 
-void proxy_socket_io(SOCKET first, SOCKET second, std::function<void(SOCKET, SOCKET)> socket_closed_callback)
+void proxy_socket_io(SOCKET first, SOCKET second, SocketClosedCallback first_socket_closed_callback, SocketClosedCallback second_socket_closed_callback)
 {
-	std::thread([=]()
-	{
+	std::thread([=]() {
 		// Send the messages received on the first socket to the second socket.
 		proxy_socket_messages(first, second);
-		socket_closed_callback(first, second);
-	});
+		first_socket_closed_callback(first);
+	}).detach();
 
-	std::thread([=]()
-	{
+	std::thread([=]() {
 		// Send the messages received on the second socket to the first socket.
 		proxy_socket_messages(second, first);
-		socket_closed_callback(first, second);
-	});
+		second_socket_closed_callback(second);
+	}).detach();
 }
 
 std::string receive_message_raw(SOCKET socket, int size)

--- a/IOSDeviceLib/SocketHelper.h
+++ b/IOSDeviceLib/SocketHelper.h
@@ -3,7 +3,6 @@
 #ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>
-#include <winsock2.h>
 #include <ws2tcpip.h>
 
 #pragma comment(lib, "Ws2_32.lib")
@@ -14,6 +13,8 @@
 #include <sys/socket.h>
 #endif
 
+#include <mutex>
+#include <thread>
 #include <map>
 #include "PlistCpp/include/boost/any.hpp"
 #include "Declarations.h"
@@ -30,7 +31,7 @@ struct LengthEncodedMessage {
 
 struct Utf16Message {
 	unsigned char *message;
-	size_t length;
+	long long length;
 
 	~Utf16Message()
 	{
@@ -39,10 +40,10 @@ struct Utf16Message {
 };
 
 LengthEncodedMessage get_message_with_encoded_length(const char* message, long long length = -1);
-Utf16Message get_utf16_message_with_encoded_length(const char* message, long long length = -1);
 int send_message(const char* message, SOCKET socket, long long length = -1);
 int send_message(std::string message, SOCKET socket, long long length = -1);
-int send_utf16_message(std::string message, SOCKET socket, long long length = -1);
 std::map<std::string, boost::any> receive_message(SOCKET socket, int timeout);
 std::map<std::string, boost::any> receive_message(SOCKET socket);
 std::string receive_message_raw(SOCKET socket, int size = 1000);
+
+void proxy_socket_io(SOCKET first, SOCKET second, std::function<void(SOCKET, SOCKET)> socket_closed_callback);

--- a/IOSDeviceLib/SocketHelper.h
+++ b/IOSDeviceLib/SocketHelper.h
@@ -46,4 +46,5 @@ std::map<std::string, boost::any> receive_message(SOCKET socket, int timeout);
 std::map<std::string, boost::any> receive_message(SOCKET socket);
 std::string receive_message_raw(SOCKET socket, int size = 1000);
 
-void proxy_socket_io(SOCKET first, SOCKET second, std::function<void(SOCKET, SOCKET)> socket_closed_callback);
+typedef std::function<void(SOCKET)> SocketClosedCallback;
+void proxy_socket_io(SOCKET first, SOCKET second, SocketClosedCallback first_socket_closed_callback, SocketClosedCallback second_socket_closed_callback);

--- a/IOSDeviceLib/SocketHelper.h
+++ b/IOSDeviceLib/SocketHelper.h
@@ -6,18 +6,19 @@
 #include <ws2tcpip.h>
 
 #pragma comment(lib, "Ws2_32.lib")
-
+#else
+typedef void* HANDLE;
+typedef unsigned long long SOCKET;
 #endif
 
 #ifndef _WIN32
 #include <sys/socket.h>
+#include <stdlib.h>
 #endif
 
-#include <mutex>
-#include <thread>
 #include <map>
+#include <functional>
 #include "PlistCpp/include/boost/any.hpp"
-#include "Declarations.h"
 
 struct LengthEncodedMessage {
 	char *message;
@@ -35,7 +36,7 @@ struct Utf16Message {
 
 	~Utf16Message()
 	{
-		free(message);
+		delete[] message;
 	}
 };
 
@@ -48,3 +49,4 @@ std::string receive_message_raw(SOCKET socket, int size = 1000);
 
 typedef std::function<void(SOCKET)> SocketClosedCallback;
 void proxy_socket_io(SOCKET first, SOCKET second, SocketClosedCallback first_socket_closed_callback, SocketClosedCallback second_socket_closed_callback);
+void close_socket(SOCKET socket);

--- a/IOSDeviceLib/SocketHelper.h
+++ b/IOSDeviceLib/SocketHelper.h
@@ -28,9 +28,21 @@ struct LengthEncodedMessage {
 	}
 };
 
+struct Utf16Message {
+	unsigned char *message;
+	size_t length;
+
+	~Utf16Message()
+	{
+		free(message);
+	}
+};
+
 LengthEncodedMessage get_message_with_encoded_length(const char* message, long long length = -1);
+Utf16Message get_utf16_message_with_encoded_length(const char* message, long long length = -1);
 int send_message(const char* message, SOCKET socket, long long length = -1);
 int send_message(std::string message, SOCKET socket, long long length = -1);
+int send_utf16_message(std::string message, SOCKET socket, long long length = -1);
 std::map<std::string, boost::any> receive_message(SOCKET socket, int timeout);
 std::map<std::string, boost::any> receive_message(SOCKET socket);
 std::string receive_message_raw(SOCKET socket, int size = 1000);

--- a/constants.js
+++ b/constants.js
@@ -3,7 +3,6 @@
 exports.DataEventName = "data";
 exports.DeviceFoundEventName = "deviceFound";
 exports.DeviceLostEventName = "deviceLost";
-exports.SocketMessageReceived = "socketMessageReceived";
 
 exports.DeviceEventEnum = {
 	kDeviceFound: "deviceFound",

--- a/constants.js
+++ b/constants.js
@@ -3,6 +3,7 @@
 exports.DataEventName = "data";
 exports.DeviceFoundEventName = "deviceFound";
 exports.DeviceLostEventName = "deviceLost";
+exports.SocketMessageReceived = "socketMessageReceived";
 
 exports.DeviceEventEnum = {
 	kDeviceFound: "deviceFound",

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const MethodNames = {
 	start: "start",
 	stop: "stop",
 	apps: "apps",
+	connectToPort: "connectToPort"
 };
 
 const Events = {
@@ -81,6 +82,10 @@ class IOSDeviceLib extends EventEmitter {
 
 	startDeviceLog(deviceIdentifiers) {
 		this._getPromise(MethodNames.log, deviceIdentifiers, { shouldEmit: true });
+	}
+
+	connectToPort(connectToPortArray) {
+		return connectToPortArray.map(connectToPortObject => this._getPromise(MethodNames.connectToPort, [connectToPortObject]));
 	}
 
 	dispose(signal) {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ const MethodNames = {
 	start: "start",
 	stop: "stop",
 	apps: "apps",
-	connectToPort: "connectToPort"
+	connectToPort: "connectToPort",
+	sendMessageToSocket: "sendMessageToSocket"
 };
 
 const Events = {
@@ -91,6 +92,10 @@ class IOSDeviceLib extends EventEmitter {
 
 	connectToPort(connectToPortArray) {
 		return connectToPortArray.map(connectToPortObject => this._getPromise(MethodNames.connectToPort, [connectToPortObject]));
+	}
+
+	sendMessageToSocket(sendMessageToSocketArray) {
+		return sendMessageToSocketArray.map(sendMessageToSocketObject => this._getPromise(MethodNames.sendMessageToSocket, [sendMessageToSocketObject]));
 	}
 
 	dispose(signal) {

--- a/index.js
+++ b/index.js
@@ -29,9 +29,10 @@ const Events = {
 };
 
 class IOSDeviceLib extends EventEmitter {
-	constructor(onDeviceFound, onDeviceLost) {
+	constructor(onDeviceFound, onDeviceLost, options) {
 		super();
-		this._iosDeviceLibStdioHandler = new IOSDeviceLibStdioHandler();
+		options = options || {};
+		this._iosDeviceLibStdioHandler = new IOSDeviceLibStdioHandler(options.debug);
 		this._iosDeviceLibStdioHandler.startReadingData();
 		this._iosDeviceLibStdioHandler.on(Constants.DeviceFoundEventName, onDeviceFound);
 		this._iosDeviceLibStdioHandler.on(Constants.DeviceLostEventName, onDeviceLost);
@@ -91,10 +92,6 @@ class IOSDeviceLib extends EventEmitter {
 
 	connectToPort(connectToPortArray) {
 		return connectToPortArray.map(connectToPortObject => this._getPromise(MethodNames.connectToPort, [connectToPortObject]));
-	}
-
-	sendMessageToSocket(sendMessageToSocketArray) {
-		return sendMessageToSocketArray.map(sendMessageToSocketObject => this._getPromise(MethodNames.sendMessageToSocket, [sendMessageToSocketObject]));
 	}
 
 	dispose(signal) {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const MethodNames = {
 	download: "download",
 	read: "read",
 	delete: "delete",
-	notify: "notify",
+	postNotification: "postNotification",
+	awaitNotificationResponse: "awaitNotificationResponse",
 	start: "start",
 	stop: "stop",
 	apps: "apps",
@@ -64,8 +65,12 @@ class IOSDeviceLib extends EventEmitter {
 		return deleteArray.map(deleteObject => this._getPromise(MethodNames.delete, [deleteObject]));
 	}
 
-	notify(notifyArray) {
-		return notifyArray.map(notificationObject => this._getPromise(MethodNames.notify, [notificationObject]));
+	postNotification(postNotificationArray) {
+		return postNotificationArray.map(notificationObject => this._getPromise(MethodNames.postNotification, [notificationObject]));
+	}
+
+	awaitNotificationRasponse(awaitNotificationResponseArray) {
+		return awaitNotificationResponseArray.map(awaitNotificationObject => this._getPromise(MethodNames.awaitNotificationResponse, [awaitNotificationObject]));
 	}
 
 	apps(deviceIdentifiers) {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class IOSDeviceLib extends EventEmitter {
 	constructor(onDeviceFound, onDeviceLost, options) {
 		super();
 		options = options || {};
-		this._iosDeviceLibStdioHandler = new IOSDeviceLibStdioHandler(options.debug);
+		this._iosDeviceLibStdioHandler = new IOSDeviceLibStdioHandler(options);
 		this._iosDeviceLibStdioHandler.startReadingData();
 		this._iosDeviceLibStdioHandler.on(Constants.DeviceFoundEventName, onDeviceFound);
 		this._iosDeviceLibStdioHandler.on(Constants.DeviceLostEventName, onDeviceLost);

--- a/index.js
+++ b/index.js
@@ -21,9 +21,7 @@ const MethodNames = {
 	start: "start",
 	stop: "stop",
 	apps: "apps",
-	connectToPort: "connectToPort",
-	sendMessageToSocket: "sendMessageToSocket",
-	readMessagesFromSocket: "readMessagesFromSocket"
+	connectToPort: "connectToPort"
 };
 
 const Events = {
@@ -97,20 +95,6 @@ class IOSDeviceLib extends EventEmitter {
 
 	sendMessageToSocket(sendMessageToSocketArray) {
 		return sendMessageToSocketArray.map(sendMessageToSocketObject => this._getPromise(MethodNames.sendMessageToSocket, [sendMessageToSocketObject]));
-	}
-
-	readMessagesFromSocket(readMessagesFromSocketArray) {
-		readMessagesFromSocketArray.forEach(readMessagesFromSocketObject => {
-			// TODO: add method to remove event handler.
-			this._iosDeviceLibStdioHandler.on(Constants.SocketMessageReceived, (data) => {
-				readMessagesFromSocketObject.callback.call(readMessagesFromSocketObject.context, data);
-			});
-			const id = uuid.v4();
-			this._iosDeviceLibStdioHandler.writeData(this._getMessage(id, MethodNames.readMessagesFromSocket, [{
-				deviceId: readMessagesFromSocketObject.deviceId,
-				socket: readMessagesFromSocketObject.socket
-			}]));
-		});
 	}
 
 	dispose(signal) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ const MethodNames = {
 	stop: "stop",
 	apps: "apps",
 	connectToPort: "connectToPort",
-	sendMessageToSocket: "sendMessageToSocket"
+	sendMessageToSocket: "sendMessageToSocket",
+	readMessagesFromSocket: "readMessagesFromSocket"
 };
 
 const Events = {
@@ -96,6 +97,20 @@ class IOSDeviceLib extends EventEmitter {
 
 	sendMessageToSocket(sendMessageToSocketArray) {
 		return sendMessageToSocketArray.map(sendMessageToSocketObject => this._getPromise(MethodNames.sendMessageToSocket, [sendMessageToSocketObject]));
+	}
+
+	readMessagesFromSocket(readMessagesFromSocketArray) {
+		readMessagesFromSocketArray.forEach(readMessagesFromSocketObject => {
+			// TODO: add method to remove event handler.
+			this._iosDeviceLibStdioHandler.on(Constants.SocketMessageReceived, (data) => {
+				readMessagesFromSocketObject.callback.call(readMessagesFromSocketObject.context, data);
+			});
+			const id = uuid.v4();
+			this._iosDeviceLibStdioHandler.writeData(this._getMessage(id, MethodNames.readMessagesFromSocket, [{
+				deviceId: readMessagesFromSocketObject.deviceId,
+				socket: readMessagesFromSocketObject.socket
+			}]));
+		});
 	}
 
 	dispose(signal) {

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ class IOSDeviceLib extends EventEmitter {
 		return postNotificationArray.map(notificationObject => this._getPromise(MethodNames.postNotification, [notificationObject]));
 	}
 
-	awaitNotificationRasponse(awaitNotificationResponseArray) {
+	awaitNotificationResponse(awaitNotificationResponseArray) {
 		return awaitNotificationResponseArray.map(awaitNotificationObject => this._getPromise(MethodNames.awaitNotificationResponse, [awaitNotificationObject]));
 	}
 

--- a/ios-device-lib-stdio-handler.js
+++ b/ios-device-lib-stdio-handler.js
@@ -50,9 +50,6 @@ class IOSDeviceLibStdioHandler extends EventEmitter {
 					this.emit(Constants.DeviceLostEventName, message);
 					this.emit(Constants.DeviceFoundEventName, message);
 					break;
-				case Constants.SocketMessageReceived:
-					this.emit(Constants.SocketMessageReceived, message);
-					break;
 			}
 		} else {
 			this.emit(Constants.DataEventName, message);

--- a/ios-device-lib-stdio-handler.js
+++ b/ios-device-lib-stdio-handler.js
@@ -21,6 +21,10 @@ class IOSDeviceLibStdioHandler extends EventEmitter {
 		this._chProc.stdout.on("data", (data) => {
 			this._unpackMessages(data);
 		});
+
+		this._chProc.stderr.on("data", (data) => {
+			console.log("TRACE: ", data);
+		});
 	}
 
 	writeData(data) {

--- a/ios-device-lib-stdio-handler.js
+++ b/ios-device-lib-stdio-handler.js
@@ -23,7 +23,7 @@ class IOSDeviceLibStdioHandler extends EventEmitter {
 		});
 
 		this._chProc.stderr.on("data", (data) => {
-			console.log("TRACE: ", data);
+			console.log("TRACE: ", data && data.toString());
 		});
 	}
 
@@ -43,10 +43,10 @@ class IOSDeviceLibStdioHandler extends EventEmitter {
 				case Constants.DeviceEventEnum.kDeviceFound:
 					this.emit(Constants.DeviceFoundEventName, message);
 					break;
-				case DeviceEventEnum.kDeviceLost:
+				case Constants.DeviceEventEnum.kDeviceLost:
 					this.emit(Constants.DeviceLostEventName, message);
 					break;
-				case DeviceEventEnum.kDeviceTrusted:
+				case Constants.DeviceEventEnum.kDeviceTrusted:
 					this.emit(Constants.DeviceLostEventName, message);
 					this.emit(Constants.DeviceFoundEventName, message);
 					break;

--- a/ios-device-lib-stdio-handler.js
+++ b/ios-device-lib-stdio-handler.js
@@ -50,6 +50,9 @@ class IOSDeviceLibStdioHandler extends EventEmitter {
 					this.emit(Constants.DeviceLostEventName, message);
 					this.emit(Constants.DeviceFoundEventName, message);
 					break;
+				case Constants.SocketMessageReceived:
+					this.emit(Constants.SocketMessageReceived, message);
+					break;
 			}
 		} else {
 			this.emit(Constants.DataEventName, message);

--- a/ios-device-lib-stdio-handler.js
+++ b/ios-device-lib-stdio-handler.js
@@ -11,9 +11,10 @@ const Constants = require("./constants");
 const HeaderSize = 4;
 
 class IOSDeviceLibStdioHandler extends EventEmitter {
-	constructor() {
+	constructor(showDebugInformation) {
 		super();
 		this._unfinishedMessage = new Buffer(0);
+		this._showDebugInformation = showDebugInformation;
 	}
 
 	startReadingData() {
@@ -22,9 +23,11 @@ class IOSDeviceLibStdioHandler extends EventEmitter {
 			this._unpackMessages(data);
 		});
 
-		this._chProc.stderr.on("data", (data) => {
-			console.log("TRACE: ", data && data.toString());
-		});
+		if (this._showDebugInformation) {
+			this._chProc.stderr.on("data", (data) => {
+				console.log("TRACE: ", data && data.toString());
+			});
+		}
 	}
 
 	writeData(data) {

--- a/ios-device-lib-stdio-handler.js
+++ b/ios-device-lib-stdio-handler.js
@@ -11,10 +11,10 @@ const Constants = require("./constants");
 const HeaderSize = 4;
 
 class IOSDeviceLibStdioHandler extends EventEmitter {
-	constructor(showDebugInformation) {
+	constructor(options) {
 		super();
 		this._unfinishedMessage = new Buffer(0);
-		this._showDebugInformation = showDebugInformation;
+		this._showDebugInformation = options.debug;
 	}
 
 	startReadingData() {

--- a/typings/interfaces.d.ts
+++ b/typings/interfaces.d.ts
@@ -80,8 +80,11 @@ declare module IOSDeviceLib {
 		response: IApplicationInfo[];
 	}
 
-	interface IDeviceLogData extends IDeviceId {
+	interface IMessage {
 		message: string;
+	}
+
+	interface IDeviceLogData extends IDeviceId, IMessage {
 	}
 
 	interface IDeviceApplication {
@@ -101,9 +104,19 @@ declare module IOSDeviceLib {
 		port: number;
 	}
 
-	interface ISendMessageToSocketData extends IDeviceId {
+	interface ISocketData extends IDeviceId {
 		socket: number;
-		message: string;
+	}
+
+	interface ISendMessageToSocketData extends ISocketData, IMessage {
+	}
+
+	interface IReceiveMessagesFromSocketData extends ISocketData {
+		callback: SocketMessageHandler;
+		context: any;
+	}
+
+	interface ISocketMessage extends ISocketData, IMessage {
 	}
 
 	interface IOSDeviceLib extends NodeJS.EventEmitter {
@@ -123,7 +136,10 @@ declare module IOSDeviceLib {
 		startDeviceLog(deviceIdentifiers: string[]): void;
 		connectToPort(connectToPortArray: IConnectToPortData[]): Promise<IDeviceResponse>[];
 		sendMessageToSocket(sendMessageToSocketArray: ISendMessageToSocketData[]): Promise<IDeviceResponse>[];
+		readMessagesFromSocket(readMessagesFromSocketArray: IReceiveMessagesFromSocketData[]): void;
 		dispose(signal?: string): void;
 		on(event: "deviceLogData", listener: (response: IDeviceLogData) => void): this;
 	}
+
+	type SocketMessageHandler = (message: ISocketMessage) => void;
 }

--- a/typings/interfaces.d.ts
+++ b/typings/interfaces.d.ts
@@ -119,6 +119,11 @@ declare module IOSDeviceLib {
 	interface ISocketMessage extends ISocketData, IMessage {
 	}
 
+	interface IConnectToPortResponse extends IDeviceId {
+		host: string;
+		port: number;
+	}
+
 	interface IOSDeviceLib extends NodeJS.EventEmitter {
 		new (onDeviceFound: (found: IDeviceActionInfo) => void, onDeviceLost: (found: IDeviceActionInfo) => void): IOSDeviceLib;
 		install(ipaPath: string, deviceIdentifiers: string[]): Promise<IDeviceResponse>[];
@@ -134,9 +139,7 @@ declare module IOSDeviceLib {
 		start(startArray: IDdiApplicationData[]): Promise<IDeviceResponse>[];
 		stop(stopArray: IDdiApplicationData[]): Promise<IDeviceResponse>[];
 		startDeviceLog(deviceIdentifiers: string[]): void;
-		connectToPort(connectToPortArray: IConnectToPortData[]): Promise<IDeviceResponse>[];
-		sendMessageToSocket(sendMessageToSocketArray: ISendMessageToSocketData[]): Promise<IDeviceResponse>[];
-		readMessagesFromSocket(readMessagesFromSocketArray: IReceiveMessagesFromSocketData[]): void;
+		connectToPort(connectToPortArray: IConnectToPortData[]): Promise<IConnectToPortResponse>[];
 		dispose(signal?: string): void;
 		on(event: "deviceLogData", listener: (response: IDeviceLogData) => void): this;
 	}

--- a/typings/interfaces.d.ts
+++ b/typings/interfaces.d.ts
@@ -32,7 +32,7 @@ declare module IOSDeviceLib {
 		path: string;
 	}
 
-	interface IFileData extends ISource, IDestination{
+	interface IFileData extends ISource, IDestination {
 	}
 
 	interface IFileOperationData extends IAppDevice, IFileData {
@@ -50,13 +50,20 @@ declare module IOSDeviceLib {
 		ddi: string;
 	}
 
-	interface INotifyData extends IDeviceId {
+	interface IPostNotificationData extends IDeviceId {
 		commandType: string;
 		notificationName: string;
 		shouldWaitForResponse: boolean;
 		timeout?: number;
 		responseCommandType?: string;
 		responsePropertyName?: string;
+	}
+
+	interface IAwaitNotificatioNResponseData extends IDeviceId {
+		responseCommandType: string;
+		responsePropertyName: string;
+		socket: number;
+		timeout: number;
 	}
 
 	interface IDeviceResponse extends IDeviceId {
@@ -107,7 +114,8 @@ declare module IOSDeviceLib {
 		download(downloadArray: IFileOperationData[]): Promise<IDeviceResponse>[];
 		read(readArray: IReadOperationData[]): Promise<IDeviceResponse>[];
 		delete(deleteArray: IDeleteFileData[]): Promise<IDeviceResponse>[];
-		notify(notifyArray: INotifyData[]): Promise<IDeviceResponse>[];
+		postNotification(postNotificationArray: IPostNotificationData[]): Promise<IDeviceResponse>[];
+		awaitNotificationResponse(awaitNotificationResponseArray: IAwaitNotificatioNResponseData[]): Promise<IDeviceResponse>[];
 		apps(deviceIdentifiers: string[]): Promise<IDeviceAppInfo>[];
 		start(startArray: IDdiApplicationData[]): Promise<IDeviceResponse>[];
 		stop(stopArray: IDdiApplicationData[]): Promise<IDeviceResponse>[];

--- a/typings/interfaces.d.ts
+++ b/typings/interfaces.d.ts
@@ -53,10 +53,6 @@ declare module IOSDeviceLib {
 	interface IPostNotificationData extends IDeviceId {
 		commandType: string;
 		notificationName: string;
-		shouldWaitForResponse: boolean;
-		timeout?: number;
-		responseCommandType?: string;
-		responsePropertyName?: string;
 	}
 
 	interface IAwaitNotificatioNResponseData extends IDeviceId {
@@ -105,6 +101,11 @@ declare module IOSDeviceLib {
 		port: number;
 	}
 
+	interface ISendMessageToSocketData extends IDeviceId {
+		socket: number;
+		message: string;
+	}
+
 	interface IOSDeviceLib extends NodeJS.EventEmitter {
 		new (onDeviceFound: (found: IDeviceActionInfo) => void, onDeviceLost: (found: IDeviceActionInfo) => void): IOSDeviceLib;
 		install(ipaPath: string, deviceIdentifiers: string[]): Promise<IDeviceResponse>[];
@@ -121,6 +122,7 @@ declare module IOSDeviceLib {
 		stop(stopArray: IDdiApplicationData[]): Promise<IDeviceResponse>[];
 		startDeviceLog(deviceIdentifiers: string[]): void;
 		connectToPort(connectToPortArray: IConnectToPortData[]): Promise<IDeviceResponse>[];
+		sendMessageToSocket(sendMessageToSocketArray: ISendMessageToSocketData[]): Promise<IDeviceResponse>[];
 		dispose(signal?: string): void;
 		on(event: "deviceLogData", listener: (response: IDeviceLogData) => void): this;
 	}


### PR DESCRIPTION
The socket returned from the ios runtime can be accessed only from the ios-device-lib. We need a way to expose it.
The solution is to create a server which listnes to a port and when the client application connects to this address we will proxy the messages from the client socket to the device socket and from the device socket to the client socket.