### PR TITLE
Detach the gdb after we kill the application

### DIFF
--- a/IOSDeviceLib/Constants.h
+++ b/IOSDeviceLib/Constants.h
@@ -7,6 +7,10 @@ static const unsigned kAFCCustomError = 4;
 static const unsigned kApplicationsCustomError = 5;
 static const unsigned kUnexpectedError = 13;
 
+static const int kSocketHasMessages = 1;
+static const int kSocketNoMessages = 0;
+static const int kSocketClosed = -1;
+
 static const unsigned kADNCIMessageConnected = 1;
 static const unsigned kADNCIMessageDisconnected = 2;
 static const unsigned kADNCIMessageUnknown = 3;

--- a/IOSDeviceLib/Declarations.h
+++ b/IOSDeviceLib/Declarations.h
@@ -259,7 +259,7 @@ extern "C"
 	unsigned AFCFileRefRead(afc_connection*, afc_file_ref, void*, size_t*);
 	unsigned AFCFileRefWrite(afc_connection*, afc_file_ref, const void*, size_t);
 	unsigned AFCFileRefClose(afc_connection*, afc_file_ref);
-    int USBMuxConnectByPort(int, int, int*);
+	unsigned USBMuxConnectByPort(int, int, long long*);
 }
 
 #endif // !_WIN32

--- a/IOSDeviceLib/GDBHelper.cpp
+++ b/IOSDeviceLib/GDBHelper.cpp
@@ -1,4 +1,5 @@
 #include "GDBHelper.h"
+#include "Constants.h"
 #include "StringHelper.h"
 #include <sstream>
 #include <iomanip>
@@ -123,8 +124,10 @@ bool stop_application(std::string & executable, SOCKET socket, std::string& appl
 	return true;
 }
 
-void detach_connection(SOCKET socket)
+void detach_connection(SOCKET socket, std::string& application_identifier, DeviceData* device_data)
 {
-	///*gdb_send_message("D", socket);
-	//std::string answer = receive_message_raw(socket);*/
+	gdb_send_message("D", socket);
+	std::string answer = receive_message_raw(socket);
+	device_data->apps_cache[application_identifier].has_initialized_gdb = false;
+	device_data->services.erase(kDebugServer);
 }

--- a/IOSDeviceLib/GDBHelper.h
+++ b/IOSDeviceLib/GDBHelper.h
@@ -8,5 +8,5 @@ std::string get_gdb_message(std::string message);
 int gdb_send_message(std::string message, SOCKET socket, long long length = -1);
 bool run_application(std::string& executable, SOCKET socket, std::string& application_identifier, std::map<std::string, ApplicationCache>& apps_cache);
 bool stop_application(std::string& executable, SOCKET socket, std::string& application_identifier, std::map<std::string, ApplicationCache>& apps_cache);
-void detach_connection(SOCKET socket);
+void detach_connection(SOCKET socket, std::string& application_identifier, DeviceData* device_data);
 

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -1175,7 +1175,7 @@ void stop_app(std::string device_identifier, std::string application_identifier,
 		else
 			print_error("Could not stop application", device_identifier, method_id, kApplicationsCustomError);
 
-		detach_connection((SOCKET)gdb);
+		detach_connection((SOCKET)gdb, application_identifier, &devices[device_identifier]);
 	}
 	else
 	{
@@ -1211,8 +1211,6 @@ void start_app(std::string device_identifier, std::string application_identifier
 			print(json({ { kResponse, "Successfully started application" },{ kId, method_id },{ kDeviceId, device_identifier } }));
 		else
 			print_error("Could not start application", device_identifier, method_id, kApplicationsCustomError);
-
-		detach_connection((SOCKET)gdb);
 	}
 	else
 	{
@@ -1280,7 +1278,7 @@ void connect_to_port(std::string device_identifier, int port, std::string method
 		// Proxy the messages from the client socket to the device socket
 		// and from the device socket to the client socket.
 		proxy_socket_io(device_socket, client_socket, [](SOCKET client_fd) {
-			closesocket(client_fd);
+			close_socket(client_fd);
 		}, [=](SOCKET d_fd) {
 			devices[device_identifier].kill_device_server();
 		});


### PR DESCRIPTION
We need to detach the gdb when we kill the application. If we don't do it, next time we try to start/stop the application we will fail.
Also we don't want to detach the gdb after we start the application, because we won't be able to stop it.