### PR TITLE
Fix find free local port

### DIFF
--- a/IOSDeviceLib/ServerHelper.cpp
+++ b/IOSDeviceLib/ServerHelper.cpp
@@ -18,11 +18,12 @@ struct sockaddr_in bind_socket(SOCKET socket, const char* host)
 	server_address.sin_port = htons(port);
 
 	// If the port is available the bind() will return 0.
-	auto bind_result = bind(socket, (sockaddr*)&server_address, address_length);
+	int bind_result = bind(socket, (sockaddr*)&server_address, address_length);
 	while (bind_result != 0)
 	{
 		++port;
 		server_address.sin_port = htons(port);
+		bind_result = bind(socket, (sockaddr*)&server_address, address_length);
 	}
 
 	return server_address;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
When 1111 port is not free, we struggle to get free port, mainly because we do not try to bind it again.
After we call bind, everything works as expected.