### PR TITLE
Fix binary path for Windows x86 builds

### DIFF
--- a/IOSDeviceLib/IOSDeviceLib.vcxproj
+++ b/IOSDeviceLib/IOSDeviceLib.vcxproj
@@ -81,7 +81,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(SolutionDir)\IOSDeviceLib\PlistCpp\include;$(IncludePath)</IncludePath>
-    <OutDir>$(SolutionDir)bin\win32\$(PlatformTarget)</OutDir>
+    <OutDir>$(SolutionDir)bin\win32\ia32</OutDir>
     <TargetName>ios-device-lib</TargetName>
     <TargetExt>.exe</TargetExt>
   </PropertyGroup>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION

Fix the path to binary to be ia32 instead of x86, as that's the name of the 32-bit platform in Node.js