### PR TITLE
Fix crash when disconnecting devices

### DIFF
--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -920,7 +920,7 @@ void get_application_infos(std::string device_identifier, std::string method_id)
 	{
 		std::map<std::string, boost::any> dict = receive_message((SOCKET)socket);
 		PRINT_ERROR_AND_RETURN_IF_FAILED_RESULT(dict.count(kErrorKey), boost::any_cast<std::string>(dict[kErrorKey]).c_str(), device_identifier, method_id);
-		if (dict.count(kStatusKey) && has_complete_status(dict))
+		if (dict.empty() || (dict.count(kStatusKey) && has_complete_status(dict)))
 		{
 			break;
 		}

--- a/IOSDeviceLib/SocketHelper.cpp
+++ b/IOSDeviceLib/SocketHelper.cpp
@@ -47,11 +47,18 @@ std::map<std::string, boost::any> receive_message_core(SOCKET socket)
 	std::map<std::string, boost::any> dict;
 	char *buffer = new char[4];
 	int bytes_read = recv(socket, buffer, 4, 0);
-	unsigned long res = ntohl(*((unsigned long*)buffer));
-	delete[] buffer;
-	buffer = new char[res];
-	bytes_read = recv(socket, buffer, res, 0);
-	Plist::readPlist(buffer, res, dict);
+	if (bytes_read > 0)
+	{
+		unsigned long res = ntohl(*((unsigned long*)buffer));
+		delete[] buffer;
+		buffer = new char[res];
+		bytes_read = recv(socket, buffer, res, 0);
+		if (bytes_read > 0)
+		{
+			Plist::readPlist(buffer, res, dict);
+		}
+	}
+
 	delete[] buffer;
 	receive_message_mutex.unlock();
 	return dict;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
Whenever disconnecting devices a query might be in progress inquiring about the device's applications. The query then may read 0 bytes of memory and due to the lack of check for this we transformed a buffer containing random memory into a number and later on allocated as much memory.
This lead to an access violation as well as a crash.

Fixes [Device detection is broken on iOS device disconnect](http://teampulse.telerik.com/view#item/345482)

Ping @TsvetanMilanov @rosen-vladimirov 