### PR TITLE
Fix uninstall on macOS

### DIFF
--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -493,8 +493,14 @@ void uninstall_application(std::string application_identifier, std::string devic
 		return;
 	}
 
+	HANDLE socket = start_service(device_identifier, kInstallationProxy, method_id);
+	if (!socket)
+	{
+		return;
+	}
+
 	CFStringRef appid_cfstring = create_CFString(application_identifier.c_str());
-	unsigned result = AMDeviceSecureUninstallApplication(0, devices[device_identifier].device_info, appid_cfstring, 0, NULL, 0);
+	unsigned result = AMDeviceUninstallApplication(socket, appid_cfstring, NULL, [] {}, NULL);
 	CFRelease(appid_cfstring);
 
 	if (result)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
Currently uninstall fails on macOS with error `InvalidArgument` (hidden behind an error code). So get back the old way of uninstalling application - use `AMDeviceUninstallApplication` instead of `AMDeviceSecureUninstallApplication`.