### PR TITLE
Fix error when application is uninstalled manually

### DIFF
--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -221,7 +221,8 @@ void cleanup_file_resources(const std::string& device_identifier)
 
 	if (devices[device_identifier].apps_cache.size())
 	{
-		for (auto const& key_value_pair : devices[device_identifier].apps_cache)
+		std::map<std::string, ApplicationCache> apps_cache_clone = devices[device_identifier].apps_cache;
+		for (auto const& key_value_pair : apps_cache_clone)
 		{
 			cleanup_file_resources(device_identifier, key_value_pair.first);
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
In case the application is uninstalled manually during working with current device, trying to install it again fails as at the end of install we are cleaning the old resources. However the for loop is modifying the object over which we iterrate and the code fails. So copy the object before iterrating over it.


