### PR TITLE
Fix stop application failure when app is uninstalled manually from device

### DIFF
--- a/IOSDeviceLib/GDBHelper.cpp
+++ b/IOSDeviceLib/GDBHelper.cpp
@@ -89,7 +89,7 @@ bool stop_application(std::string & executable, SOCKET socket, std::string& appl
 	RETURN_IF_FALSE(init(executable, socket, application_identifier, apps_cache));
 	// If we just send kill here it doesn't work
 	// I believe it is due to some racing condition because when I send kill I sometimes receive an error and sometimes - nothing
-	
+
 	std::string answer;
 	bool can_send_kill = false;
 	for (size_t _ = 0; _ < kRetryCount; _++)
@@ -129,5 +129,13 @@ void detach_connection(SOCKET socket, std::string& application_identifier, Devic
 	gdb_send_message("D", socket);
 	std::string answer = receive_message_raw(socket);
 	device_data->apps_cache[application_identifier].has_initialized_gdb = false;
-	device_data->services.erase(kDebugServer);
+	erase_gdb_instance(device_data);
+}
+
+void erase_gdb_instance(DeviceData* device_data)
+{
+	if (device_data->services.count(kDebugServer))
+	{
+		device_data->services.erase(kDebugServer);
+	}
 }

--- a/IOSDeviceLib/GDBHelper.h
+++ b/IOSDeviceLib/GDBHelper.h
@@ -9,4 +9,5 @@ int gdb_send_message(std::string message, SOCKET socket, long long length = -1);
 bool run_application(std::string& executable, SOCKET socket, std::string& application_identifier, std::map<std::string, ApplicationCache>& apps_cache);
 bool stop_application(std::string& executable, SOCKET socket, std::string& application_identifier, std::map<std::string, ApplicationCache>& apps_cache);
 void detach_connection(SOCKET socket, std::string& application_identifier, DeviceData* device_data);
+void erase_gdb_instance(DeviceData* device_data);
 

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -586,6 +586,7 @@ void install_application(std::string install_path, std::string device_identifier
 	print(json({ { kResponse, "Successfully installed application" }, { kId, method_id }, {kDeviceId, device_identifier}}));
 	// In case this is a REinstall we need to invalidate cached file resources
 	cleanup_file_resources(device_identifier);
+	erase_gdb_instance(&devices[device_identifier]);
 }
 
 void perform_detached_operation(void(*operation)(std::string, std::string), std::string arg, std::string method_id)


### PR DESCRIPTION
In case you have the following workflow
- start application on device from C++ code
- uninstall the application manually
- install the application from C++ code
- call stop_application (i.e. restart - stop-start)

The code fails as the gdb instance returns empty answers. In order to resolve the issue, clean the gdb server instance when app is installed. This way when the stop_application method is called, we'll init a new gdb and the stop will return correct results.