### PR TITLE
Fix promises sometimes not resolved

### DIFF
--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -1294,6 +1294,7 @@ int main()
 {
 #ifdef _WIN32
 	_setmode(_fileno(stdout), _O_BINARY);
+	_setmode(_fileno(stderr), _O_BINARY);
 
 	if (load_dlls())
 	{

--- a/message-unpack-stream.js
+++ b/message-unpack-stream.js
@@ -40,21 +40,13 @@ exports.MessageUnpackStream = class MessageUnpackStream extends stream.Transform
 				this.push(messageBuffer);
 				this._endUnpackingMessages(done);
 			}
-		} else if (this._unfinishedMessage.length && data.length >= HeaderSize) {
+		} else {
 			// Append the new data to the unfinished message and try to unpack again.
 			const concatenatedMessage = Buffer.concat([this._unfinishedMessage, data]);
 
 			// Clear the unfinished message buffer.
 			this._unfinishedMessage = new Buffer(0);
 			this._transform(concatenatedMessage);
-			this._endUnpackingMessages(done);
-		} else {
-			// While debugging the data here contains one character - \0, null or 0.
-			// I think we get here when the Node inner buffer for the data of the data event
-			// is filled with data and the last symbol is a part of the length header of the next message.
-			// That's why we need this concat.
-			// This code is tested with 10 000 000 messages in while loop.
-			this._unfinishedMessage = Buffer.concat([this._unfinishedMessage, data]);
 			this._endUnpackingMessages(done);
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
Includes:
* Remove code _tested with 10 000 000 messages in while loop._

In the cases where we end up in the deleted `else` statement we do not call `_transform` recursively, which leads to the fact that the initial promise is never resolved.

One can end up in the deleted `else` block if `stdout` or `stderr` is set to `_O_TEXT` mode and a message is printed which is exactly 10 symbols on Windows. Any message on a `_O_TEXT` buffer [has its line feeds replaced with a carriage-return line feed pair](https://msdn.microsoft.com/en-us/library/h9t88zwz.aspx#Anchor_2). Due to the fact that the number 10 represents the ASCII code for a line feed we are liable to error in that way.

Note that the `stderr` pipe is currently unused in the production code, so there's no need to rebuild the binaries prior to publishing a new version of the library.

Ping @rosen-vladimirov @TsvetanMilanov 