### PR TITLE
Don't cache the notification proxy service

### DIFF
--- a/IOSDeviceLib/CommonFunctions.h
+++ b/IOSDeviceLib/CommonFunctions.h
@@ -7,7 +7,7 @@
 #include "Declarations.h"
 
 inline bool has_complete_status(std::map<std::string, boost::any>& dict);
-HANDLE start_service(std::string device_identifier, const char* service_name, std::string method_id, bool should_log_error = true);
+HANDLE start_service(std::string device_identifier, const char* service_name, std::string method_id, bool should_log_error = true, bool skip_cache = false);
 bool mount_image(std::string& device_identifier, std::string& image_path, std::string& method_id);
 std::string get_device_property_value(std::string& device_identifier, const char* property_name);
 int start_session(std::string& device_identifier);

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -350,7 +350,7 @@ void start_run_loop()
 }
 
 std::mutex start_service_mutex;
-HANDLE start_service(std::string device_identifier, const char* service_name, std::string method_id, bool should_log_error)
+HANDLE start_service(std::string device_identifier, const char* service_name, std::string method_id, bool should_log_error, bool skip_cache)
 {
 	start_service_mutex.lock();
 	if (!devices.count(device_identifier))
@@ -385,7 +385,9 @@ HANDLE start_service(std::string device_identifier, const char* service_name, st
 		return NULL;
 	}
 
-	devices[device_identifier].services[service_name] = socket;
+	if (!skip_cache) {
+		devices[device_identifier].services[service_name] = socket;
+	}
 
 	start_service_mutex.unlock();
 	return socket;
@@ -1058,7 +1060,7 @@ void device_log(std::string device_identifier, std::string method_id)
 
 void post_notification(std::string device_identifier, PostNotificationInfo post_notification_info, std::string method_id)
 {
-	HANDLE handle = start_service(device_identifier, kNotificationProxy, method_id);
+	HANDLE handle = start_service(device_identifier, kNotificationProxy, method_id, true, true);
 	if (!handle)
 	{
 		return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
When we execute awaitNotification and there is no response we will wait to
receive something from the notification proxy service socket. If we execute it
again while we are waiting the response from the first call we will start
waiting for response on the same socket. If only one response comes in the
socket one of the calls will get it and the other one will continue
waiting. To avoid this we should not cache the notification proxy service
(the socket). This way each call will start new service and wait for response
on different socket.

We had problems on some devices when we start new service for every call
before we started to use the ios-device-lib. That's why we want to disable
the cache only for the notification service proxy.

Tests with 500 postNotification invocations:
- there are no repeating sockets
- sending messages to each socket returns correct bytes sent count

There is also a workaround which will not fix the problem but it will make
it harder to reproduce. We can implement timeout in receive_message method
and this way we will wait for response only for 1 second for example. The bug
will appear only if we execute awaitNotification two times in 1 second.