### PR TITLE
fix: Unhandled Rejection is thrown from device logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
In case device logs are currently printed, but the device is detached from the machine, Unhandled Rejection is thrown.
The problem is that the Promise for device log is never awaited.
Add option to skip the rejection in this case.