### PR TITLE
fix: Unable to assign to constant variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ class IOSDeviceLib extends EventEmitter {
 			};
 
 			deviceLostHandler = (device) => {
-				const message = `Device ${device.deviceId} lost during operation ${methodName} for message ${id}`;
+				let message = `Device ${device.deviceId} lost during operation ${methodName} for message ${id}`;
 
 				if (!options.doNotFailOnDeviceLost) {
 					message = { error: new Error(message) };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
In case device is detached during waiting for some action (except device logs) we should reject the promise and throw an error.
In this case we construct a string message, persist it in a constant variable and later we try to reassing the value of the constant variable.
Node.js raises an error - "TypeError: Assignment to constant variable"...
We must use let, not const here.