### PR TITLE
fix: optimize message receive for big messages

### DIFF
--- a/IOSDeviceLib/SocketHelper.h
+++ b/IOSDeviceLib/SocketHelper.h
@@ -17,6 +17,7 @@ typedef unsigned long long SOCKET;
 #endif
 
 #include <map>
+#include <string>
 #include <functional>
 #include "PlistCpp/include/boost/any.hpp"
 
@@ -31,13 +32,7 @@ struct LengthEncodedMessage {
 };
 
 struct Utf16Message {
-	unsigned char *message;
-	long long length;
-
-	~Utf16Message()
-	{
-		delete[] message;
-	}
+    std::string message;
 };
 
 LengthEncodedMessage get_message_with_encoded_length(const char* message, long long length = -1);


### PR DESCRIPTION
related to https://github.com/NativeScript/nativescript-cli/issues/4226

Seems that the following code causes 100% CPU usage:
```C
memcpy(temp, result, final_length);	
memcpy(temp + final_length, buffer, bytes_read);
```
so the code is refactored to use `std::string`