### PR TITLE
fix: add timeout when awaiting notification response

### DIFF
--- a/IOSDeviceLib/Declarations.h
+++ b/IOSDeviceLib/Declarations.h
@@ -267,7 +267,7 @@ extern "C"
 {
 	CFSocketNativeHandle  AMDServiceConnectionGetSocket(ServiceConnRef con);
 	long AMDServiceConnectionReceive(ServiceConnRef, void *, long);
-    void AMDServiceConnectionInvalidate(ServiceConnRef);
+	void AMDServiceConnectionInvalidate(ServiceConnRef);
 	long AMDServiceConnectionSendMessage(ServiceConnRef serviceConnection, CFDictionaryRef message, CFPropertyListFormat format);
 	unsigned AMDeviceSecureStartService(AMDeviceRef device, CFStringRef service_name, unsigned int *unknown, ServiceConnRef * handle);
 	unsigned AMDeviceNotificationSubscribe(void(*f)(const DevicePointer*), long, long, long, HANDLE*);

--- a/IOSDeviceLib/Declarations.h
+++ b/IOSDeviceLib/Declarations.h
@@ -267,6 +267,7 @@ extern "C"
 {
 	CFSocketNativeHandle  AMDServiceConnectionGetSocket(ServiceConnRef con);
 	long AMDServiceConnectionReceive(ServiceConnRef, void *, long);
+    void AMDServiceConnectionInvalidate(ServiceConnRef);
 	long AMDServiceConnectionSendMessage(ServiceConnRef serviceConnection, CFDictionaryRef message, CFPropertyListFormat format);
 	unsigned AMDeviceSecureStartService(AMDeviceRef device, CFStringRef service_name, unsigned int *unknown, ServiceConnRef * handle);
 	unsigned AMDeviceNotificationSubscribe(void(*f)(const DevicePointer*), long, long, long, HANDLE*);

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -1007,7 +1007,7 @@ void get_application_infos(std::string device_identifier, std::string method_id)
 	std::vector<json> livesync_app_infos;
 	while (true)
 	{
-		std::map<std::string, boost::any> dict = receive_con_message(serviceInfo.connection);
+		std::map<std::string, boost::any> dict = receive_con_message(serviceInfo.connection, device_identifier, method_id, 0);
 		PRINT_ERROR_AND_RETURN_IF_FAILED_RESULT(dict.count(kErrorKey), boost::any_cast<std::string>(dict[kErrorKey]).c_str(), device_identifier, method_id);
 		if (dict.empty() || (dict.count(kStatusKey) && has_complete_status(dict)))
 		{
@@ -1181,7 +1181,7 @@ void await_notification_response(std::string device_identifier, AwaitNotificatio
 	PRINT_ERROR_AND_RETURN_IF_FAILED_RESULT(connection == nullptr, invalid_connection_error_message.c_str(), device_identifier, method_id);
 	
 	ServiceInfo currentNotificationProxy = devices[device_identifier].services[kNotificationProxy];
-	std::map<std::string, boost::any> response = receive_con_message(connection);
+	std::map<std::string, boost::any> response = receive_con_message(connection, device_identifier, method_id, await_notification_response_info.timeout);
 	if (response.size())
 	{
 		PRINT_ERROR_AND_RETURN_IF_FAILED_RESULT(response.count(kErrorKey), boost::any_cast<std::string>(response[kErrorKey]).c_str(), device_identifier, method_id);

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -1002,7 +1002,7 @@ void get_application_infos(std::string device_identifier, std::string method_id)
 	std::vector<json> livesync_app_infos;
 	while (true)
 	{
-		std::map<std::string, boost::any> dict = receive_con_message(serviceInfo.connection, device_identifier, method_id, 0);
+		std::map<std::string, boost::any> dict = receive_con_message(serviceInfo.connection, device_identifier, method_id, 10);
 		PRINT_ERROR_AND_RETURN_IF_FAILED_RESULT(dict.count(kErrorKey), boost::any_cast<std::string>(dict[kErrorKey]).c_str(), device_identifier, method_id);
 		if (dict.empty() || (dict.count(kStatusKey) && has_complete_status(dict)))
 		{

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -210,11 +210,6 @@ void cleanup_file_resources(const std::string& device_identifier, const std::str
 		AFCConnectionClose(afc_connection_to_close);
 		devices[device_identifier].apps_cache.erase(application_identifier);
 	}
-
-	if (devices[device_identifier].services.count(kHouseArrest))
-	{
-		devices[device_identifier].services.erase(kHouseArrest);
-	}
 }
 
 void cleanup_file_resources(const std::string& device_identifier)
@@ -982,13 +977,13 @@ void get_application_infos(std::string device_identifier, std::string method_id)
 	
 	CFStringRef cf_app_type_value = create_CFString("User");
 	const void *client_opts_values_arr[] = { cf_app_type_value, cf_return_attributes_array };
-	CFDictionaryRef clinet_opts_dict = CFDictionaryCreate(NULL, client_opts_keys_arr, client_opts_values_arr, 2, NULL, NULL);
+	CFDictionaryRef client_opts_dict = CFDictionaryCreate(NULL, client_opts_keys_arr, client_opts_values_arr, 2, NULL, NULL);
 	
 	CFStringRef cf_command_key = create_CFString("Command");
 	CFStringRef cf_client_options_key = create_CFString("ClientOptions");
 	const void *keys_arr[] = { cf_command_key, cf_client_options_key };
 	CFStringRef cf_command_value = create_CFString("Browse");
-	const void *values_arr[] = { cf_command_value, clinet_opts_dict };
+	const void *values_arr[] = { cf_command_value, client_opts_dict };
 	CFDictionaryRef dict_command = CFDictionaryCreate(NULL, keys_arr, values_arr, 2, NULL, NULL);
 
 	send_con_message(serviceInfo.connection, dict_command);
@@ -998,7 +993,7 @@ void get_application_infos(std::string device_identifier, std::string method_id)
 	CFRelease(cf_app_type_key);
 	CFRelease(cf_return_attrs_key);
 	CFRelease(cf_app_type_value);
-	CFRelease(clinet_opts_dict);
+	CFRelease(client_opts_dict);
 	CFRelease(cf_command_key);
 	CFRelease(cf_client_options_key);
 	CFRelease(cf_command_value);

--- a/IOSDeviceLib/SocketHelper.cpp
+++ b/IOSDeviceLib/SocketHelper.cpp
@@ -21,11 +21,13 @@ std::map<std::string, boost::any> receive_con_message(ServiceConnRef con, std::s
     
     bool isSuccessful = false;
     
-    setTimeout([=]() {
-        if (!isSuccessful) {
-            AMDServiceConnectionInvalidate(con);
-        }
-    }, timeout);
+    if (timeout > 0) {
+        setTimeout([=]() {
+            if (!isSuccessful) {
+                AMDServiceConnectionInvalidate(con);
+            }
+        }, timeout);
+    }
     
     std::map<std::string, boost::any> dict;
     char *buffer = new char[4];

--- a/IOSDeviceLib/SocketHelper.h
+++ b/IOSDeviceLib/SocketHelper.h
@@ -41,7 +41,7 @@ LengthEncodedMessage get_message_with_encoded_length(const char* message, long l
 int send_message(const char* message, SOCKET socket, long long length = -1);
 int send_message(std::string message, SOCKET socket, long long length = -1);
 long send_con_message(HANDLE* serviceConnection, CFDictionaryRef message);
-std::map<std::string, boost::any> receive_con_message(HANDLE* con);
+std::map<std::string, boost::any> receive_con_message(HANDLE* con, std::string device_identifier, std::string method_id, int timeout);
 std::map<std::string, boost::any> receive_message(SOCKET socket, int timeout = 5);
 std::string receive_message_raw(SOCKET socket, int size = 1000);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
All socket connections were changed and now are started in ssl mode. This changes the way messages are sent and received from sockets. As a result, `timeout` option is not anymore respected when receiving messages from socket. However, the messages now are received only via methods from mobile device lib. As there isn't a built-in method in mobile device that can work with timeout, we implemented timeout mechanism using threads. The `await_notification_response` operation is started in separate thread and after the provided timeout, the started thread is terminated.

Rel to https://github.com/NativeScript/nativescript-cli/issues/4966