### PR TITLE
fix: do not cache the installation proxy

### DIFF
--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -531,7 +531,7 @@ void uninstall_application(std::string application_identifier, std::string devic
 		return;
 	}
 
-	ServiceInfo serviceInfo = start_secure_service(device_identifier, kInstallationProxy, method_id, true, false);
+	ServiceInfo serviceInfo = start_secure_service(device_identifier, kInstallationProxy, method_id, true, true);
 	if (!serviceInfo.socket)
 	{
 		return;
@@ -961,7 +961,7 @@ void read_file(std::string device_identifier, const char *application_identifier
 
 void get_application_infos(std::string device_identifier, std::string method_id)
 {
-	ServiceInfo serviceInfo = start_secure_service(device_identifier, kInstallationProxy, method_id, true, false);
+	ServiceInfo serviceInfo = start_secure_service(device_identifier, kInstallationProxy, method_id, true, true);
 	if (!serviceInfo.socket)
 	{
 		return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
It seems like the installation proxy service dies at some point, but as we cache it, we do not understand that and the operation fails. This usually happens when we try to get the applications installed on device - try it several times for 10-15 seconds and the operation will start returning empty array