### PR TITLE
fix: clear timeout after receiving successfully message from socket's connection

### DIFF
--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -303,7 +303,7 @@ void device_notification_callback(const DevicePointer* device_ptr)
 		case kADNCIMessageDisconnected:
 		{
 			if (devices.count(device_identifier)) {
-                int interface_type = AMDeviceGetInterfaceType(device_ptr->device_info);
+				int interface_type = AMDeviceGetInterfaceType(device_ptr->device_info);
 				if (interface_type == kUSBInterfaceType) {
 					devices[device_identifier].isUSBConnected = 0;
 				} else if (interface_type == kWIFIInterfaceType) {
@@ -1003,7 +1003,7 @@ void get_application_infos(std::string device_identifier, std::string method_id)
 	std::vector<json> livesync_app_infos;
 	while (true)
 	{
-        std::map<std::string, boost::any> dict = receive_con_message(serviceInfo.connection, device_identifier, method_id, 0);
+		std::map<std::string, boost::any> dict = receive_con_message(serviceInfo.connection, device_identifier, method_id, 0);
 		PRINT_ERROR_AND_RETURN_IF_FAILED_RESULT(dict.count(kErrorKey), boost::any_cast<std::string>(dict[kErrorKey]).c_str(), device_identifier, method_id);
 		if (dict.empty() || (dict.count(kStatusKey) && has_complete_status(dict)))
 		{

--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -531,7 +531,7 @@ void uninstall_application(std::string application_identifier, std::string devic
 		return;
 	}
 
-	ServiceInfo serviceInfo = start_secure_service(device_identifier, kInstallationProxy, method_id, true, true);
+	ServiceInfo serviceInfo = start_secure_service(device_identifier, kInstallationProxy, method_id, true, false);
 	if (!serviceInfo.socket)
 	{
 		return;
@@ -961,7 +961,7 @@ void read_file(std::string device_identifier, const char *application_identifier
 
 void get_application_infos(std::string device_identifier, std::string method_id)
 {
-	ServiceInfo serviceInfo = start_secure_service(device_identifier, kInstallationProxy, method_id, true, true);
+	ServiceInfo serviceInfo = start_secure_service(device_identifier, kInstallationProxy, method_id, true, false);
 	if (!serviceInfo.socket)
 	{
 		return;
@@ -1003,7 +1003,7 @@ void get_application_infos(std::string device_identifier, std::string method_id)
 	std::vector<json> livesync_app_infos;
 	while (true)
 	{
-		std::map<std::string, boost::any> dict = receive_con_message(serviceInfo.connection, device_identifier, method_id, 10);
+        std::map<std::string, boost::any> dict = receive_con_message(serviceInfo.connection, device_identifier, method_id, 0);
 		PRINT_ERROR_AND_RETURN_IF_FAILED_RESULT(dict.count(kErrorKey), boost::any_cast<std::string>(dict[kErrorKey]).c_str(), device_identifier, method_id);
 		if (dict.empty() || (dict.count(kStatusKey) && has_complete_status(dict)))
 		{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-device-lib",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "",
   "types": "./typings/ios-device-lib.d.ts",
   "main": "index.js",


### PR DESCRIPTION
A specified timeout is set when receiving a message from socket's connection. However, this timeout is never cleared. This lead to the issue that socket's connection is invalidated when receiving successfully message. After that it is not possible to use the socket's connection again in the same process.

It seems that `mobile-device` lib doesn't clear automatically connections. Starting a service with skip_cache: true can potentially lead to some random issues regarding the allowed count of started services on device.