### PR TITLE
fix: don't stuck on "Restarting application" when some error occurs while stopping the application

### DIFF
--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -1257,6 +1257,7 @@ void stop_app(std::string device_identifier, std::string application_identifier,
 		HANDLE gdb = start_debug_server(device_identifier, ddi, method_id);
 		if (!gdb)
 		{
+			print_error("Unable to start gdb server", device_identifier, method_id, kUnexpectedError);
 			return;
 		}
 


### PR DESCRIPTION
Currently when the application is stopped, NativeScript CLI hangs up on "Restarting application". This happens as we're no able to start `gdb server` due to some error. (for example, not mounted developer disk image on device). In this situation, `ios-device-lib` doesn't print any message back to the CLI and this way the entire `tns run` command is blocked. Printing error in this situation will ensure that NativeScript CLI will continue the command execution.

Rel to https://github.com/NativeScript/nativescript-cli/issues/5020