### PR TITLE
fix: fix the behavior of setTimeout

### DIFF
--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -659,7 +659,7 @@ std::map<std::string, boost::any> receive_con_message(ConnectionMessageData data
 	receive_con_message_mutex.lock();
 	
 	ServiceConnRef conn = data.conn;
-	TimeoutOutputData timeoutOutputData = setTimeout(data.timeout, &data, clean_con_resources);
+	TimeoutOutputData* timeoutOutputData = setTimeout(data.timeout, &data, clean_con_resources);
 
 	std::map<std::string, boost::any> dict;
 	char *buffer = new char[4];
@@ -673,12 +673,10 @@ std::map<std::string, boost::any> receive_con_message(ConnectionMessageData data
 		if (bytes_read > 0)
 		{
 			Plist::readPlist(buffer, res, dict);
-			clearTimeout(timeoutOutputData);
 		}
-	} else {
-		clearTimeout(timeoutOutputData);
 	}
 
+	clearTimeout(timeoutOutputData);
 	delete[] buffer;
 	receive_con_message_mutex.unlock();
 	return dict;
@@ -1052,7 +1050,7 @@ void get_application_infos(std::string device_identifier, std::string method_id)
 	std::vector<json> livesync_app_infos;
 	while (true)
 	{
-		ConnectionMessageData connectionMessageData = { serviceInfo.connection, device_identifier, method_id, kInstallationProxy, 10 };
+		ConnectionMessageData connectionMessageData = { serviceInfo.connection, device_identifier, method_id, kInstallationProxy, 0 };
 		std::map<std::string, boost::any> dict = receive_con_message(connectionMessageData);
 		PRINT_ERROR_AND_RETURN_IF_FAILED_RESULT(dict.count(kErrorKey), boost::any_cast<std::string>(dict[kErrorKey]).c_str(), device_identifier, method_id);
 		if (dict.empty() || (dict.count(kStatusKey) && has_complete_status(dict)))

--- a/IOSDeviceLib/SetTimeout.h
+++ b/IOSDeviceLib/SetTimeout.h
@@ -36,5 +36,5 @@ struct TimeoutOutputData {
     TimeoutData* timeoutData;
 };
 
-TimeoutOutputData setTimeout(int timeout, void * data, void(*operation)(void*));
-void clearTimeout(TimeoutOutputData data);
+TimeoutOutputData* setTimeout(int timeout, void * data, void(*operation)(void*));
+void clearTimeout(TimeoutOutputData* data);


### PR DESCRIPTION
Currently `ios-device-lib` hangs when listing the installed applications on connected device. This happens when application is ran using sidekick. The applications are gathered from device on every 200ms. It seems that for some reasons, `ios-device-lib` is not able to create new `std::thread` and it hangs on `std::thread(operation)` on some windows machines. The result from listed applications is reported by chunks and a new `std::thread` is created for every reported chunk. As a workaround of this problem, we'll set timeout to `0` when listing the applications. (It was the default behavior before introducing `setTimeout` function). This PR also changes the interface of `setTimeout` and `clearTimeout` and makes them working with pointers instead of structs.