### PR TITLE
Guard against USBMuxConnectByPort failure before using socket

### DIFF
--- a/IOSDeviceLib/IOSDeviceLib.cpp
+++ b/IOSDeviceLib/IOSDeviceLib.cpp
@@ -1581,6 +1581,12 @@ void connect_to_port(std::string device_identifier, int port,
   int usb_result =
       USBMuxConnectByPort(connection_id, htons(port), &device_socket);
 
+  if (usb_result != 0) {
+    print_error("Failed to perform mux connect on device.", device_identifier,
+                method_id, usb_result);
+    return;
+  }
+
   if (device_socket < 0) {
     print_error("USBMuxConnectByPort returned bad file descriptor",
                 device_identifier, method_id, usb_result);


### PR DESCRIPTION
When `USBMuxConnectByPort` returns a non-zero error code, `connect_to_port` falls through and uses a potentially invalid `device_socket`. This causes downstream failures (EPIPE, broken pipe) during device communication.

Added an early return with `print_error` when `usb_result != 0`, consistent with the existing error handling pattern right below it (the `device_socket < 0` check).