### PR TITLE
ci: build binaries and publish to npm with provenance from GitHub Actions

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,9 +1,13 @@
 name: 'Build native binaries'
 
-# Reusable job set: compiles the C++ binary the JavaScript layer spawns, for
-# every platform the package ships, and publishes each as a workflow artifact.
-# Called by the test workflow (to catch native breakage on PRs) and by the
-# release workflow (to assemble the package).
+# Reusable job set: compiles the C++ binary the JavaScript layer spawns and
+# publishes it as a workflow artifact. Called by the test workflow (to catch
+# native breakage on PRs) and by the release workflow (to assemble the package).
+#
+# Only macOS is built. The Windows sources have not compiled since the iOS 17
+# changes (unconditional <dlfcn.h>, dlsym lookup of SSL_free, a MobileDevice
+# entry point declared for macOS only, and winsock.h reaching the compiler
+# before winsock2.h); add a windows-latest job here once they do.
 
 on:
   workflow_call:
@@ -40,42 +44,3 @@ jobs:
           path: bin/darwin/ios-device-lib
           if-no-files-found: error
 
-  win32:
-    name: win32 (${{ matrix.arch }})
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # "platform" is the solution-level name msbuild expects; "arch" is
-          # the directory os.arch() resolves at runtime.
-          - platform: x64
-            arch: x64
-          - platform: x86
-            arch: ia32
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
-
-      - name: Build
-        # The project files pin the VS2015 toolset and the 8.1 SDK, neither of
-        # which the hosted runners carry; the overrides select the installed ones.
-        run: >-
-          msbuild IOSDeviceLib.sln /m /nologo /verbosity:minimal
-          /p:Configuration=Release
-          /p:Platform=${{ matrix.platform }}
-          /p:PlatformToolset=v143
-          /p:WindowsTargetPlatformVersion=10.0
-
-      - name: Verify binary
-        shell: bash
-        run: test -s "bin/win32/${{ matrix.arch }}/ios-device-lib.exe"
-
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: bin-win32-${{ matrix.arch }}
-          path: bin/win32/${{ matrix.arch }}/ios-device-lib.exe
-          if-no-files-found: error

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,0 +1,81 @@
+name: 'Build native binaries'
+
+# Reusable job set: compiles the C++ binary the JavaScript layer spawns, for
+# every platform the package ships, and publishes each as a workflow artifact.
+# Called by the test workflow (to catch native breakage on PRs) and by the
+# release workflow (to assemble the package).
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  darwin:
+    name: darwin (x86_64 + arm64)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Build
+        run: |
+          xcodebuild -project IOSDeviceLib.xcodeproj -scheme IOSDeviceLib \
+            -configuration Release -quiet \
+            ARCHS="x86_64 arm64" ONLY_ACTIVE_ARCH=NO \
+            DEBUG_INFORMATION_FORMAT=dwarf \
+            build
+
+      - name: Verify universal binary
+        run: |
+          lipo -info bin/darwin/ios-device-lib
+          lipo bin/darwin/ios-device-lib -verify_arch x86_64 arm64
+          codesign --verify --verbose bin/darwin/ios-device-lib
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: bin-darwin
+          path: bin/darwin/ios-device-lib
+          if-no-files-found: error
+
+  win32:
+    name: win32 (${{ matrix.arch }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # "platform" is the solution-level name msbuild expects; "arch" is
+          # the directory os.arch() resolves at runtime.
+          - platform: x64
+            arch: x64
+          - platform: x86
+            arch: ia32
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
+
+      - name: Build
+        # The project files pin the VS2015 toolset and the 8.1 SDK, neither of
+        # which the hosted runners carry; the overrides select the installed ones.
+        run: >-
+          msbuild IOSDeviceLib.sln /m /nologo /verbosity:minimal
+          /p:Configuration=Release
+          /p:Platform=${{ matrix.platform }}
+          /p:PlatformToolset=v143
+          /p:WindowsTargetPlatformVersion=10.0
+
+      - name: Verify binary
+        shell: bash
+        run: test -s "bin/win32/${{ matrix.arch }}/ios-device-lib.exe"
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: bin-win32-${{ matrix.arch }}
+          path: bin/win32/${{ matrix.arch }}/ios-device-lib.exe
+          if-no-files-found: error

--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -113,21 +113,11 @@ jobs:
           name: bin-darwin
           path: bin/darwin
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bin-win32-x64
-          path: bin/win32/x64
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bin-win32-ia32
-          path: bin/win32/ia32
-
       - name: Assemble binaries
-        # artifacts do not preserve file modes; the darwin binary is spawned directly
+        # artifacts do not preserve file modes; the binary is spawned directly
         run: |
           chmod +x bin/darwin/ios-device-lib
-          find bin -type f -exec ls -l {} \;
+          ls -l bin/darwin
 
       - name: Build ios-device-lib
         run: npm pack

--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -1,0 +1,247 @@
+name: 'ios-device-lib -> npm'
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: >-
+          Release to cut. Leave empty for a rolling "next" prerelease (no version
+          bump). "dev" publishes a -dev prerelease (no bump). A semver keyword
+          (patch/minor/major) or an explicit version (e.g. 0.9.6, 0.10.0-alpha.1)
+          bumps package.json, commits + tags v<version>, then publishes a stable
+          release. A prerelease version publishes under the dist-tag matching its
+          prerelease id (alpha/beta/rc); a plain version publishes under "latest".
+        type: string
+        required: false
+        default: ''
+
+permissions: read-all
+
+env:
+  NPM_TAG: 'next'
+
+jobs:
+  native:
+    name: Native
+    uses: ./.github/workflows/build-native.yml
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs:
+      - native
+    permissions:
+      contents: write
+    outputs:
+      npm_version: ${{ steps.npm_version_output.outputs.NPM_VERSION }}
+      npm_tag: ${{ steps.npm_version_output.outputs.NPM_TAG }}
+      is_release: ${{ steps.npm_version_output.outputs.IS_RELEASE }}
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.14.0
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Setup
+        run: npm ci --ignore-scripts
+
+      - name: Get Current Version
+        run: |
+          NPM_VERSION=$(node -e "console.log(require('./package.json').version);")
+          echo NPM_VERSION=$NPM_VERSION >> $GITHUB_ENV
+
+      - name: Bump, commit and tag stable release (manual dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type != '' && inputs.release_type != 'dev' }}
+        env:
+          # env indirection keeps the free-text dispatch input out of shell interpolation
+          RELEASE_INPUT: ${{ inputs.release_type }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # npm version accepts a semver keyword (patch/minor/major) or an explicit
+          # version; strip an optional leading "v" so v0.9.6 and 0.9.6 both work.
+          npm version "${RELEASE_INPUT#v}" -m "chore: release v%s"
+          NPM_VERSION=$(node -e "console.log(require('./package.json').version);")
+          echo NPM_VERSION=$NPM_VERSION >> $GITHUB_ENV
+          git push origin HEAD:${GITHUB_REF_NAME} --follow-tags
+
+      - name: Bump version for dev release
+        if: ${{ !contains(github.ref, 'refs/tags/') && (github.event_name != 'workflow_dispatch' || inputs.release_type == '' || inputs.release_type == 'dev') }}
+        env:
+          NPM_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type == 'dev' && 'dev' || 'next' }}
+        run: |
+          NPM_VERSION=$(node ./scripts/get-next-version.js)
+          echo NPM_VERSION=$NPM_VERSION >> $GITHUB_ENV
+          npm version $NPM_VERSION --no-git-tag-version
+
+      - name: Output NPM Version and tag
+        id: npm_version_output
+        env:
+          # true only for a manual dispatch that cut a real (bumped) release — not
+          # the empty "next" build or the "dev" channel. Computed in the GitHub
+          # expression context so the free-text input never reaches the shell.
+          IS_DISPATCH_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type != '' && inputs.release_type != 'dev' }}
+        run: |
+          NPM_TAG=$(node ./scripts/get-npm-tag.js)
+          if [[ "${GITHUB_REF}" == refs/tags/* ]] || [[ "$IS_DISPATCH_RELEASE" == "true" ]]; then
+            IS_RELEASE=true
+          else
+            IS_RELEASE=false
+          fi
+          echo NPM_VERSION=$NPM_VERSION >> $GITHUB_OUTPUT
+          echo NPM_TAG=$NPM_TAG >> $GITHUB_OUTPUT
+          echo IS_RELEASE=$IS_RELEASE >> $GITHUB_OUTPUT
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bin-darwin
+          path: bin/darwin
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bin-win32-x64
+          path: bin/win32/x64
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bin-win32-ia32
+          path: bin/win32/ia32
+
+      - name: Assemble binaries
+        # artifacts do not preserve file modes; the darwin binary is spawned directly
+        run: |
+          chmod +x bin/darwin/ios-device-lib
+          find bin -type f -exec ls -l {} \;
+
+      - name: Build ios-device-lib
+        run: npm pack
+
+      - name: Upload npm package artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: npm-package
+          path: ios-device-lib-${{steps.npm_version_output.outputs.NPM_VERSION}}.tgz
+          if-no-files-found: error
+
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    needs:
+      - build
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      NPM_VERSION: ${{needs.build.outputs.npm_version}}
+      NPM_TAG: ${{needs.build.outputs.npm_tag}}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.14.0
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-package
+          path: dist
+
+      - name: Update npm (required for OIDC trusted publishing)
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
+
+      - name: Publish package (OIDC trusted publishing)
+        if: ${{ vars.USE_NPM_TOKEN != 'true' }}
+        run: |
+          echo "Publishing ios-device-lib@$NPM_VERSION to NPM with tag $NPM_TAG via OIDC trusted publishing..."
+          unset NODE_AUTH_TOKEN
+          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ]; then
+            rm -f "$NPM_CONFIG_USERCONFIG"
+          fi
+          npm publish ./dist/ios-device-lib-${{env.NPM_VERSION}}.tgz --tag $NPM_TAG --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ""
+
+      - name: Publish package (granular token)
+        if: ${{ vars.USE_NPM_TOKEN == 'true' }}
+        run: |
+          echo "Publishing ios-device-lib@$NPM_VERSION to NPM with tag $NPM_TAG via granular token..."
+          npm publish ./dist/ios-device-lib-${{env.NPM_VERSION}}.tgz --tag $NPM_TAG --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+  github-release:
+    runs-on: ubuntu-latest
+    # runs for tag pushes and for manual dispatches that bumped a stable release
+    if: ${{ needs.build.outputs.is_release == 'true' }}
+    permissions:
+      contents: write
+    needs:
+      - build
+    env:
+      NPM_VERSION: ${{needs.build.outputs.npm_version}}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: v${{needs.build.outputs.npm_version}}
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.14.0
+
+      - name: Setup
+        run: npm ci --ignore-scripts
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-package
+          path: dist
+
+      - name: Generate provenance statement
+        run: |
+          TGZ_PATH=$(ls dist/ios-device-lib-*.tgz | head -n1)
+          TGZ_NAME=$(basename "$TGZ_PATH")
+          TGZ_SHA=$(sha256sum "$TGZ_PATH" | awk '{ print $1 }')
+          PROV_PATH="dist/${TGZ_NAME%.tgz}.intoto.jsonl"
+
+          cat > "$PROV_PATH" <<EOT
+          {"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"$TGZ_NAME","digest":{"sha256":"$TGZ_SHA"}}],"predicateType":"https://slsa.dev/provenance/v1"}
+          EOT
+
+      - name: Partial Changelog
+        run: npx conventional-changelog -p angular -r2 > body.md
+
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+        with:
+          tag: v${{needs.build.outputs.npm_version}}
+          artifacts: "dist/ios-device-lib-*.tgz,dist/ios-device-lib-*.intoto.jsonl"
+          bodyFile: "body.md"
+          prerelease: ${{needs.build.outputs.npm_tag != 'latest'}}
+          allowUpdates: true

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,54 @@
+name: Preview release
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native:
+    name: Native
+    uses: ./.github/workflows/build-native.yml
+
+  preview:
+    name: Publish preview package (pkg.pr.new)
+    runs-on: ubuntu-latest
+    needs:
+      - native
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bin-darwin
+          path: bin/darwin
+
+      - name: Assemble binaries
+        # artifacts do not preserve file modes; the binary is spawned directly
+        run: chmod +x bin/darwin/ios-device-lib
+
+      - name: Publish preview package
+        run: npx pkg-pr-new publish --compact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: 'Tests'
+
+on:
+  pull_request:
+  push:
+    branches: [ 'master' ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [ '20.x', '22.x', '24.x' ]
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci --ignore-scripts
+
+      - name: Test
+        run: npm test
+
+  native:
+    name: Native
+    uses: ./.github/workflows/build-native.yml

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Releases are built and published by the `ios-device-lib -> npm` GitHub Actions w
 * Every push to `master` publishes a rolling prerelease under the `next` dist-tag.
 * To cut a stable release, run the workflow manually (Actions -> `ios-device-lib -> npm` -> Run workflow) and enter a semver keyword (`patch`, `minor`, `major`) or an explicit version (e.g. `0.9.6`). The workflow bumps `package.json`, commits, tags `v<version>`, publishes under `latest` (or the prerelease id's dist-tag for `0.10.0-alpha.1` style versions) and creates a GitHub release with the tarball attached.
 * Pushing a `v*` tag by hand also publishes that version.
+* Every push to `master` and every pull request also publishes a preview build to [pkg.pr.new](https://pkg.pr.new); the bot comments the install URL on the pull request (`npm i https://pkg.pr.new/ios-device-lib@<sha>`).
 
 Publishing uses npm trusted publishing (OIDC) from the `npm-publish` environment, so no npm token is stored in the repository. To publish with a granular token instead, set the repository variable `USE_NPM_TOKEN` to `true` and store the token in the `NPM_PUBLISH_TOKEN` secret.
 

--- a/README.md
+++ b/README.md
@@ -37,22 +37,13 @@ The `ios-device-lib` package can be built on either Windows (requires Visual Stu
 
 Releasing
 ==
-When you want to release a new version, you should build the binaries for macOS and Windows. To do this, please follow the steps below:
-1. On Windows machine, open IOSDeviceLib.sln file with Visual Studio.
-2. Select Release configuration and x64 architecture.
-3. Build the application.
-4. Now switch the architecture to x86.
-5. Build the application again.
-6. After that open the `<repo dir>\bin\win32` - you will find two dirs there - `ia32` and `x64`.
-7. Open both of the directories and delete all files except the `ios-device-lib.exe` file.
-8. Copy the win32 dir to your Mac machine.
-9. Open the repository on macOS
-10. With Xcode open the `IOSDeviceLib.xcodeproj`
-11. Build the product in Release mode (Cmd + Shift + B on my side).
-12. Open the `<repo dir>/bin/darwin` directory and check if you have `x64` dir there with a single binary file in it.
-13. Inside `<repo dir>/bin/` put the `win32` directory that you've copied from your Windows machine.
-14. At the root of the repository execute `npm pack` - this will produce a new .tgz file.
-15. Publish the `.tgz` file in `npm`.
+Releases are built and published by the `ios-device-lib -> npm` GitHub Actions workflow (`.github/workflows/npm_release.yml`), which compiles the binaries on hosted macOS and Windows runners, packs them together with the JavaScript layer, and publishes to npm with provenance. The manual Xcode/Visual Studio build is only needed for local development.
+
+* Every push to `master` publishes a rolling prerelease under the `next` dist-tag.
+* To cut a stable release, run the workflow manually (Actions -> `ios-device-lib -> npm` -> Run workflow) and enter a semver keyword (`patch`, `minor`, `major`) or an explicit version (e.g. `0.9.6`). The workflow bumps `package.json`, commits, tags `v<version>`, publishes under `latest` (or the prerelease id's dist-tag for `0.10.0-alpha.1` style versions) and creates a GitHub release with the tarball attached.
+* Pushing a `v*` tag by hand also publishes that version.
+
+Publishing uses npm trusted publishing (OIDC) from the `npm-publish` environment, so no npm token is stored in the repository. To publish with a granular token instead, set the repository variable `USE_NPM_TOKEN` to `true` and store the token in the `NPM_PUBLISH_TOKEN` secret.
 
 Inter-process Communication
 ==

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The `ios-device-lib` package can be built on either Windows (requires Visual Stu
 
 Releasing
 ==
-Releases are built and published by the `ios-device-lib -> npm` GitHub Actions workflow (`.github/workflows/npm_release.yml`), which compiles the binaries on hosted macOS and Windows runners, packs them together with the JavaScript layer, and publishes to npm with provenance. The manual Xcode/Visual Studio build is only needed for local development.
+Releases are built and published by the `ios-device-lib -> npm` GitHub Actions workflow (`.github/workflows/npm_release.yml`), which compiles the universal macOS binary on a hosted macOS runner, packs it together with the JavaScript layer, and publishes to npm with provenance. The manual Xcode build is only needed for local development. Windows binaries are not currently built: the Windows sources stopped compiling with the iOS 17 changes and need to be repaired before a `windows-latest` job can be added to `build-native.yml`.
 
 * Every push to `master` publishes a rolling prerelease under the `next` dist-tag.
 * To cut a stable release, run the workflow manually (Actions -> `ios-device-lib -> npm` -> Run workflow) and enter a semver keyword (`patch`, `minor`, `major`) or an explicit version (e.g. `0.9.6`). The workflow bumps `package.json`, commits, tags `v<version>`, publishes under `latest` (or the prerelease id's dist-tag for `0.10.0-alpha.1` style versions) and creates a GitHub release with the tarball attached.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ios-device-lib",
-  "version": "0.9.5-dev.0",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ios-device-lib",
-      "version": "0.9.5-dev.0",
+      "version": "0.9.5",
       "license": "Apache-2.0",
       "dependencies": {
         "bufferpack": "0.0.6",
@@ -14,99 +14,111 @@
       },
       "devDependencies": {
         "chai": "4.2.0",
+        "conventional-changelog-cli": "5.0.0",
         "husky": "^5.1.3",
         "istanbul": "0.4.5",
         "lint-staged": "^10.5.4",
-        "mocha": "5.2.0"
+        "mocha": "5.2.0",
+        "semver": "7.7.3"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.12.13"
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+      "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "color-convert": "^1.9.0"
+        "@simple-libs/child-process-utils": "^1.0.0",
+        "@simple-libs/stream-utils": "^1.2.0",
+        "semver": "^7.5.2"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+    "node_modules/@hutson/parse-repository-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-5.0.0.tgz",
+      "integrity": "sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==",
       "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+      "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "@simple-libs/stream-utils": "^1.2.0"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
       }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -119,6 +131,13 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
+    },
+    "node_modules/add-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+      "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
@@ -199,6 +218,13 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -399,11 +425,251 @@
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/conventional-changelog": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-6.0.0.tgz",
+      "integrity": "sha512-tuUH8H/19VjtD9Ig7l6TQRh+Z0Yt0NZ6w/cCkkyzUbGQTnUEmKfGtkC9gGfVgCfOL1Rzno5NgNF4KY8vR+Jo3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-changelog-angular": "^8.0.0",
+        "conventional-changelog-atom": "^5.0.0",
+        "conventional-changelog-codemirror": "^5.0.0",
+        "conventional-changelog-conventionalcommits": "^8.0.0",
+        "conventional-changelog-core": "^8.0.0",
+        "conventional-changelog-ember": "^5.0.0",
+        "conventional-changelog-eslint": "^6.0.0",
+        "conventional-changelog-express": "^5.0.0",
+        "conventional-changelog-jquery": "^6.0.0",
+        "conventional-changelog-jshint": "^5.0.0",
+        "conventional-changelog-preset-loader": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-atom": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-5.1.0.tgz",
+      "integrity": "sha512-fw7GpI9jHNCWGBnTsPRI452ypQbNupGwsjrXfozvRNE0c92pJRpoj9rXfzDKUYJcsmk0H4XKaQjhjelwI9z27w==",
+      "deprecated": "This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-5.0.0.tgz",
+      "integrity": "sha512-9Y8fucJe18/6ef6ZlyIlT2YQUbczvoQZZuYmDLaGvcSBP+M6h+LAvf7ON7waRxKJemcCII8Yqu5/8HEfskTxJQ==",
+      "deprecated": "This package is no longer maintained. Please use the conventional-changelog package instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "add-stream": "^1.0.0",
+        "conventional-changelog": "^6.0.0",
+        "meow": "^13.0.0",
+        "tempfile": "^5.0.0"
+      },
+      "bin": {
+        "conventional-changelog": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-codemirror": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-5.1.0.tgz",
+      "integrity": "sha512-iXhy63YczB+yWA9DrsYbquSYLvWKsK9M3WC+xQPEm8cOn4oXzKpmTp2uH3qi7+i10oTcGJTvq9lsBpZmMADaNg==",
+      "deprecated": "This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-core": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-8.0.0.tgz",
+      "integrity": "sha512-EATUx5y9xewpEe10UEGNpbSHRC6cVZgO+hXQjofMqpy+gFIrcGvH3Fl6yk2VFKh7m+ffenup2N7SZJYpyD9evw==",
+      "deprecated": "Deprecated and no longer maintained. Please use conventional-changelog instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hutson/parse-repository-url": "^5.0.0",
+        "add-stream": "^1.0.0",
+        "conventional-changelog-writer": "^8.0.0",
+        "conventional-commits-parser": "^6.0.0",
+        "git-raw-commits": "^5.0.0",
+        "git-semver-tags": "^8.0.0",
+        "hosted-git-info": "^7.0.0",
+        "normalize-package-data": "^6.0.0",
+        "read-package-up": "^11.0.0",
+        "read-pkg": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-ember": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-5.1.0.tgz",
+      "integrity": "sha512-XNcgGcdJt7wh341BBML0CI8DKpqE5lKD1WahzFHGZFvKTzJr1rZW976cw7beqKLOBbzdrH9ZIkE/s2TfbOuM3g==",
+      "deprecated": "This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-eslint": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-6.1.0.tgz",
+      "integrity": "sha512-beWr3qzuEMN9gznMWa8PhTVfGkGXoq+XnUzViNXg5KygrgV728ZRqZngz3uPhz5+ayUhPrpNFYqIE0qHWz9NAw==",
+      "deprecated": "This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-5.1.0.tgz",
+      "integrity": "sha512-g/s9eLohrefYTSNQaB6+k0ONbiVx41YOKBbIOIM3ST/NtedAgppCJnrpKXVN9sOmpPkN4vjFwURlfvpEDUjoeg==",
+      "deprecated": "This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-jquery": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-6.1.0.tgz",
+      "integrity": "sha512-/sFhULybhFrMg+qc8MHHHSj7kTVMfx5C7rSM6Z9EjduVoAQJdGRq/wpv/SWPMQ+KPNSYHqDLwm/x2Z5hOcYvqQ==",
+      "deprecated": "This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-jshint": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-5.2.0.tgz",
+      "integrity": "sha512-OaatyvHXP1fjI7Mx0b1IkmhbhTsVHsytnsQSkOj4rhGbFMoTcfvbwm/vAtCzRMXOxojK1EDMBBmBj1pM9KNy/Q==",
+      "deprecated": "This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-preset-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
+      "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-writer": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+      "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "conventional-commits-filter": "^5.0.0",
+        "handlebars": "^4.7.7",
+        "meow": "^13.0.0",
+        "semver": "^7.5.2"
+      },
+      "bin": {
+        "conventional-changelog-writer": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.0",
@@ -490,6 +756,29 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dot-prop/node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/emoji-regex": {
@@ -646,6 +935,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -682,6 +984,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/git-raw-commits": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
+      "integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
+      "deprecated": "Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.6.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/git-semver-tags": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-8.0.1.tgz",
+      "integrity": "sha512-zMbamckSNdlT4U48IMFa2Cn6FTzM+2yF6/gEmStPJI8PiLxd/bT6dw10+mc6u5Qe4fhrc/y9nU290FWjQhAV7g==",
+      "deprecated": "Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.6.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "git-semver-tags": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/glob": {
       "version": "5.0.15",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -709,13 +1047,14 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },
@@ -754,6 +1093,19 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/human-signals": {
@@ -810,6 +1162,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inflight": {
@@ -928,7 +1293,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.14.0",
@@ -1130,6 +1496,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -1296,6 +1682,21 @@
         "nopt": "bin/nopt.js"
       }
     },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1439,6 +1840,13 @@
         "node": "*"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -1479,6 +1887,88 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
@@ -1517,6 +2007,19 @@
       },
       "engines": {
         "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {
@@ -1578,6 +2081,42 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -1655,6 +2194,32 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/tempfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-5.0.0.tgz",
+      "integrity": "sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "temp-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -1725,6 +2290,19 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/uuid": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
@@ -1736,6 +2314,17 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -17,24 +17,26 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telerik/ios-device-lib.git"
+    "url": "git+https://github.com/NativeScript/ios-device-lib.git"
   },
   "author": "",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/telerik/ios-device-lib/issues"
+    "url": "https://github.com/NativeScript/ios-device-lib/issues"
   },
-  "homepage": "https://github.com/telerik/ios-device-lib#readme",
+  "homepage": "https://github.com/NativeScript/ios-device-lib#readme",
   "dependencies": {
     "bufferpack": "0.0.6",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
     "chai": "4.2.0",
+    "conventional-changelog-cli": "5.0.0",
     "husky": "^5.1.3",
     "istanbul": "0.4.5",
     "lint-staged": "^10.5.4",
-    "mocha": "5.2.0"
+    "mocha": "5.2.0",
+    "semver": "7.7.3"
   },
   "lint-staged": {
     "*.{cpp,h}": "clang-format -style=llvm -i"

--- a/scripts/get-next-version.js
+++ b/scripts/get-next-version.js
@@ -1,0 +1,62 @@
+const semver = require("semver");
+const child_process = require("child_process");
+const fs = require("fs");
+
+const currentVersion =
+  process.env.NPM_VERSION || require("../package.json").version;
+
+if (!currentVersion) {
+  throw new Error("Invalid current version");
+}
+const currentTag = process.env.NPM_TAG || "next";
+const runID = process.env.GITHUB_RUN_ID || 0;
+
+let prPrerelease = "";
+
+if (currentTag === "pr" && process.env.GITHUB_EVENT_PATH) {
+  try {
+    const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+    const prNum = ev.pull_request.number;
+    // add extra PR number to version-pr.PRNUM-....
+    prPrerelease = `${prNum}-`;
+  } catch (e) {
+    // don't add pr prerelease
+  }
+}
+
+// Format date as YYYY-MM-DD using native Date
+const now = new Date();
+const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+
+const preRelease = `${currentTag}.${prPrerelease}${dateStr}-${runID}`;
+
+let lastTagVersion = (
+  process.env.LAST_TAGGED_VERSION ||
+  child_process
+    .spawnSync("git", ["describe", "--tags", "--abbrev=0", "--match=v*"])
+    .stdout.toString()
+)
+  .trim()
+  // git describe emits the tag verbatim (v9.1.0); LAST_TAGGED_VERSION callers
+  // pass a bare version, which for scoped packages has no "v" to strip
+  .replace(/^v/, "");
+if (!semver.parse(lastTagVersion)) {
+  throw new Error("Invalid last tag version");
+}
+
+function setPreRelease(version) {
+  const parsed = semver.parse(version);
+  return semver.parse(
+    `${parsed.major}.${parsed.minor}.${parsed.patch}-${preRelease}`
+  );
+}
+
+let nextVersion = setPreRelease(currentVersion);
+
+// bump patch if the current version is lower or equal to the last tagged version
+if (semver.lte(nextVersion, lastTagVersion)) {
+  nextVersion = semver.inc(lastTagVersion, "patch");
+  nextVersion = setPreRelease(nextVersion);
+}
+
+console.log(nextVersion.version);

--- a/scripts/get-npm-tag.js
+++ b/scripts/get-npm-tag.js
@@ -1,0 +1,19 @@
+const semver = require("semver");
+
+const currentVersion =
+  process.env.NPM_VERSION || require("../package.json").version;
+
+function validateNpmTag(version) {
+  const parsed = semver.parse(version);
+  return (
+    parsed.prerelease.length === 0 || /^[a-zA-Z]+$/.test(parsed.prerelease[0])
+  );
+}
+
+function getNpmTag(version) {
+  if (!validateNpmTag(version)) throw new Error("Invalid npm tag");
+  const parsed = semver.parse(version);
+  return parsed.prerelease[0] || "latest";
+}
+
+console.log(getNpmTag(currentVersion));


### PR DESCRIPTION
## Why

Releases are currently assembled by hand (Xcode build, Visual Studio builds, copy the results together, `npm pack`, `npm publish`). That is easy to get wrong: 0.9.5 on npm ships an **arm64-only** macOS binary (the stdio handler expects a universal one, so Intel Macs cannot spawn it) and **no Windows binaries**, where 0.9.4 shipped `bin/win32/{x64,ia32}`.

This adds the same release pipeline the NativeScript CLI uses (`NativeScript/nativescript-cli`, `npm_release_cli.yml`), adapted to build the native binary in CI.

## What

- **`build-native.yml`** (reusable, `workflow_call`): compiles the universal x86_64+arm64 macOS binary with `xcodebuild` on `macos-latest`, verifies it with `lipo -verify_arch` and `codesign --verify`, and uploads it as an artifact.
- **`tests.yml`**: on every PR and push to `master`, runs the mocha suite on Node 20/22/24 and the native build.
- **`npm_release.yml`**: same shape as the CLI's workflow.
  - push to `master` → rolling `next` prerelease (`0.9.5-next.<date>-<run>`), no bump
  - push a `v*` tag → publish that version
  - manual dispatch with `patch`/`minor`/`major` or an explicit version → bumps `package.json`, commits, tags `v<version>`, publishes (under `latest`, or the prerelease id's dist-tag), and creates a GitHub release with the tarball and an in-toto statement attached
  - publishing uses npm **trusted publishing (OIDC)** with `--provenance` from the `npm-publish` environment; a granular-token fallback is available by setting the `USE_NPM_TOKEN` repository variable to `true` and providing `NPM_PUBLISH_TOKEN`
- **`preview-release.yml`**: mirrors the NativeScript core repo's workflow. Every push to `master` and every PR publishes the packed package (with the freshly built macOS binary) to [pkg.pr.new](https://pkg.pr.new), and the bot comments the install URL on the PR (`npm i https://pkg.pr.new/ios-device-lib@<sha>`), so a fix like #86 can be tried in a CLI project before it is released.
- `scripts/get-next-version.js` and `scripts/get-npm-tag.js` are copied from the CLI repo; `semver` and `conventional-changelog-cli` are added as devDependencies for them.
- `package.json` `repository`/`bugs`/`homepage` now point at `NativeScript/ios-device-lib` instead of `telerik/…`. npm refuses `--provenance` publishes when `repository.url` does not match the repository the workflow runs in, so this is required, not cosmetic.
- README "Releasing" section rewritten to describe the workflow.

All actions are pinned to commit SHAs (the same pins the CLI repo uses).

## Windows is not built (yet)

I first included a `windows-latest` msbuild job. It fails because the Windows sources have not compiled since #81 (which is presumably why 0.9.5 has no `bin/win32`):

- `IOSDeviceLib.cpp` includes `<dlfcn.h>` unconditionally and resolves `SSL_free` via `dlsym(RTLD_DEFAULT, …)`.
- `SocketHelper.cpp` calls `AMDServiceConnectionSend`, which `Declarations.h` declares only inside `#ifndef _WIN32` (the Windows `GET_IF_EXISTS` table has no entry for it).
- `GDBHelper.cpp` passes a `HANDLE` to `closesocket`.
- A translation unit pulls `winsock.h` in ahead of `winsock2.h` (`winsock2.h: 'WSAAsyncSelect': redefinition; different linkage`, then a cascade in `ws2ipdef.h`).

The project files also pin the VS2015 toolset and the 8.1 SDK, which hosted runners don't have; `/p:PlatformToolset=v143 /p:WindowsTargetPlatformVersion=10.0` gets past that. Repairing the sources is a separate change; once they build, a windows-latest job slots into `build-native.yml` and two `download-artifact` steps into the release job.

## One-time setup needed by a maintainer before the first release

1. On npmjs.com, package `ios-device-lib` → Settings → **Trusted publisher**: GitHub Actions, repository `NativeScript/ios-device-lib`, workflow `npm_release.yml`, environment `npm-publish`.
2. In this repo, create the `npm-publish` environment (Settings → Environments). Optionally require reviewers on it to gate publishes.
3. Install the [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) on this repository so the preview workflow can publish.

Until (1) is done, the `publish` job fails with an auth error; the `build` job and its artifacts still run and can be inspected.

## Verification

- Local: `xcodebuild` with the exact flags from the workflow produces a universal binary and no dSYM; `npm test` passes; `npm pack --dry-run` lists the binary, the JS layer and typings only; the version scripts output `0.9.5-next.<date>-0`, `latest` for `0.9.6` and `alpha` for `0.10.0-alpha.1`.
- The `Tests` workflow ran on the same commits in my fork (edusperoni/ios-device-lib#1): mocha on Node 20/22/24 and the macOS universal build all pass.

